### PR TITLE
Extract QEL v0.1 and add gated VOI Product Received admission

### DIFF
--- a/.env.qel.example
+++ b/.env.qel.example
@@ -1,0 +1,15 @@
+# Product Received remains disabled unless every required control is configured.
+QEL_PRODUCT_RECEIVED_ENABLED=false
+
+# Rotate before use. Never commit a real value.
+QEL_INGEST_API_KEY=replace-with-secret-from-secret-manager
+
+# Comma-separated VSR/Quantum Arc warehouse node identifiers.
+QEL_WAREHOUSE_NODES=urn:vsr:node:warehouse-001
+
+# JSON object: DigitalMe operator ID -> allowed EmpireOS licence references.
+QEL_PRODUCT_RECEIVED_LICENSES={"did:digitalme:operator-001":["urn:empireos:license:warehouse-receiving-001"]}
+
+# RiverOS endpoint must return a receipt bound to the submitted expression digest.
+RIVEROS_RECEIPT_ENDPOINT=https://riveros.example.invalid/api/v1/receipts
+RIVEROS_API_KEY=replace-with-riveros-service-secret

--- a/.github/workflows/qel-conformance.yml
+++ b/.github/workflows/qel-conformance.yml
@@ -1,0 +1,29 @@
+name: QEL conformance
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  qel-core:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install -e './qel-core[dev]'
+      - run: pytest qel-core/tests
+
+  console:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+      - run: npm ci
+      - run: npm run check
+      - run: npm run build

--- a/.github/workflows/qel-conformance.yml
+++ b/.github/workflows/qel-conformance.yml
@@ -25,5 +25,6 @@ jobs:
           node-version: "20"
           cache: npm
       - run: npm ci
+      - run: npm run test:qel-ingest
       - run: npm run check
       - run: npm run build

--- a/README.md
+++ b/README.md
@@ -1,127 +1,37 @@
-# Quantum Vision by QEL
+# Quantum Expression Language
 
-**Quantum Vision by QEL** is a quantum-native visual intelligence framework that combines:
+This repository contains the original QEL console prototype and the first extracted QEL v0.1 foundation.
 
-- **Quantum Vision** – visual perception and decisioning modeled directly in quantum feature spaces, and  
-- **QEL (Quantum Extremal Learning)** – a variational quantum learning paradigm that optimizes for *extremal* objectives (e.g., anomaly score maxima, risk minima, optimal control boundaries).
+## Repository state
 
-This Replit project is the working environment for:
+The pre-extraction application is preserved at the immutable snapshot branch:
 
-- The **technical white paper**,
-- The **product / market positioning narrative**, and
-- Future **interactive demo / pitch deck UI**.
+- `archive/qel-console-2026-07-21`
 
----
+New standards work is isolated under:
 
-## Concept at a Glance
+- `qel-spec/` — normative language draft, schema, semantics, and conformance vectors
+- `qel-core/` — Python reference validator, canonicalizer, hasher, and CLI
+- `qel-spec/examples/voi/` — five-event VOI pilot
+- `/api/qel/*` and `/qel-pilot` — read-only console reconnection
 
-### Why this exists
+## Canonical definition
 
-Classical computer vision (CNNs, transformers, etc.) is running into:
+Quantum Expression Language (QEL) is a neutral, versioned language for expressing signed claims about observations, actions, states, authorizations, and attestations with explicit authority, consent, evidence, provenance, and lifecycle status.
 
-- **Scaling limits** – ever-larger models and datasets for marginal gains,  
-- **Cost constraints** – training and inference are increasingly expensive,  
-- **Complexity ceilings** – some high-dimensional problems remain stubbornly hard.
+A valid QEL expression is **not automatically a true fact**. It is a structurally valid, integrity-protected claim whose evidentiary weight depends on its issuer, authority, proof, evidence, independent attestations, and dispute status.
 
-**Quantum Vision by QEL** explores how quantum feature spaces and extremal learning can:
+## Development
 
-- Model richer high-order correlations in visual data,
-- Converge faster on *decision-critical* tasks (e.g., anomaly detection),
-- Potentially unlock new efficiency and performance regimes.
+```bash
+npm ci
+npm run check
+npm run build
 
----
+python -m pip install -e './qel-core[dev]'
+pytest qel-core/tests
+qel validate qel-spec/examples/voi/001-product-received.json
+qel hash qel-spec/examples/voi/001-product-received.json
+```
 
-## Architecture: High-Level
-
-1. **Visual Data Ingestion**
-   - Images, video, multi-sensor streams.
-   - Pre-processing and normalization.
-
-2. **Quantum Feature Encoding**
-   - Visual inputs mapped into **quantum states** via feature maps.
-   - Encodes complex correlations that are hard to represent classically.
-
-3. **QEL Core (Quantum Extremal Learning)**
-   - Variational quantum circuit as the trainable backbone.
-   - Optimization targets extremal values of key objectives (e.g., anomaly score, risk score).
-
-4. **Hybrid Control Plane**
-   - Classical layer for orchestration, monitoring, and integration.
-   - Quantum layer for high-value inference and extremal decisioning.
-
-5. **Application Adapters**
-   - Robotics and autonomous systems,
-   - Industrial inspection and QC,
-   - MedTech imaging,
-   - Sensing and reconnaissance.
-
----
-
-## Documentation
-
-The detailed white paper outline and narrative live in:
-
-- `docs/QUANTUM_VISION_QEL_WHITEPAPER.md`
-
-That document contains:
-
-- Context & motivation,
-- Technical underpinnings (QML + QEL),
-- System design,
-- Use cases and commercialization strategy,
-- Roadmap, risk, and governance.
-
----
-
-## How to Use This Replit
-
-You can treat this project as:
-
-1. **A documentation hub**  
-   - Iterate the white paper (`docs/...`) as the concept matures.
-   - Use `README.md` as the investor-/partner-facing landing summary.
-
-2. **A prototype front-end** (optional / future)  
-   - Add a simple web app (React, Vite, or plain HTML/JS) that:
-     - Renders the white paper sections as navigable pages,
-     - Allows switching between **Technical View** and **Market View**,
-     - Includes a "Pitch Deck Mode" that steps through key slides.
-
-3. **A playground for QEL experiments**  
-   - Add a `/src` or `/notebooks` directory for:
-     - Quantum circuit prototypes,
-     - QEL training experiments,
-     - Classical baselines for comparison.
-
----
-
-## Roadmap (Working Draft)
-
-- **Phase 0 – Narrative & Design**
-  - Finalize white paper outline.
-  - Align technical and commercial language.
-- **Phase 1 – Simulation**
-  - Implement QEL-style extremal learning on classical simulators.
-  - Benchmark vs classical baselines on small visual tasks.
-- **Phase 2 – Hybrid Prototype**
-  - Integrate with a cloud QPU provider (or simulator QPU backend).
-  - Demonstrate end-to-end quantum vision pipeline on a narrow use case.
-- **Phase 3 – Domain Pilots**
-  - Co-design pilots in industrial inspection / robotics / imaging.
-  - Ship a governed, observability-first stack suitable for regulated sectors.
-
----
-
-## Status
-
-This repository is currently in the **Concept + Architecture** phase:
-
-- White paper outline → in `docs/QUANTUM_VISION_QEL_WHITEPAPER.md`
-- Implementation details → to be iterated in `/src` or notebooks
-- Pitch deck / investor narrative → can be generated from this base
-
-Contributions and extensions should preserve:
-
-- **Engineering discipline** (clear assumptions, measurable claims),
-- **Governance and auditability** (especially for mission-critical use),
-- **Hardware-agnostic design** (not locked to a single QPU vendor).
+See `docs/QEL_V0_1_EXTRACTION.md` for the extraction boundary and roadmap.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ New standards work is isolated under:
 - `qel-spec/` — normative language draft, schema, semantics, and conformance vectors
 - `qel-core/` — Python reference validator, canonicalizer, hasher, and CLI
 - `qel-spec/examples/voi/` — five-event VOI pilot
-- `/api/qel/*` and `/qel-pilot` — read-only console reconnection
+- `/api/qel/*` and `/qel-pilot` — console reconnection and controlled pilot status
 
 ## Canonical definition
 
@@ -21,10 +21,31 @@ Quantum Expression Language (QEL) is a neutral, versioned language for expressin
 
 A valid QEL expression is **not automatically a true fact**. It is a structurally valid, integrity-protected claim whose evidentiary weight depends on its issuer, authority, proof, evidence, independent attestations, and dispute status.
 
+## Controlled Product Received gate
+
+Only `org.voijeans.inventory.product-received.v1` has a production-shaped write path. It is disabled by default and requires:
+
+- ingest authentication;
+- strict request validation;
+- an allowlisted VSR/Quantum Arc warehouse node;
+- an allowlisted DigitalMe operator and EmpireOS licence reference;
+- an idempotency key;
+- an accepted RiverOS receipt bound to the exact expression digest.
+
+Inventory Transferred, Product Sold, Product Returned, and Payment Settled remain read-only conformance fixtures.
+
+See:
+
+- `docs/VOI_PRODUCT_RECEIVED_RUNBOOK.md`
+- `docs/PRODUCT_RECEIVED_ACCEPTANCE_RECORD.md`
+- `.env.qel.example`
+- `qel-spec/examples/voi/live/product-received-request.template.json`
+
 ## Development
 
 ```bash
 npm ci
+npm run test:qel-ingest
 npm run check
 npm run build
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -16,12 +16,14 @@ import ArchitectureExplainer from "@/pages/architecture";
 import Workspace from "@/pages/workspace";
 import Briefing from "@/pages/briefing";
 import DevKit from "@/pages/devkit";
+import QelPilot from "@/pages/qel-pilot";
 
 function Router() {
   return (
     <Switch>
       <Route path="/" component={Login} />
       <Route path="/dashboard" component={Dashboard} />
+      <Route path="/qel-pilot" component={QelPilot} />
       <Route path="/workspace" component={Workspace} />
       <Route path="/briefing" component={Briefing} />
       <Route path="/devkit" component={DevKit} />

--- a/client/src/components/layout.tsx
+++ b/client/src/components/layout.tsx
@@ -1,5 +1,5 @@
 import { Link, useLocation } from "wouter";
-import { Zap, LayoutDashboard, Settings, Activity, Calculator, LogOut, Menu, Video, BookOpen, ShieldAlert, Network, Briefcase, FileCode, Cpu } from "lucide-react";
+import { Zap, LayoutDashboard, Settings, Activity, Calculator, LogOut, Menu, Video, BookOpen, ShieldAlert, Network, Briefcase, FileCode, Cpu, FileCheck2 } from "lucide-react";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { Button } from "@/components/ui/button";
 import { useState } from "react";
@@ -11,8 +11,8 @@ const NavItem = ({ href, icon: Icon, label }: { href: string; icon: any; label: 
   return (
     <Link href={href}>
       <a className={`flex items-center gap-3 px-4 py-3 rounded-md transition-all duration-200 group ${
-        isActive 
-          ? "bg-primary/10 text-primary border border-primary/20" 
+        isActive
+          ? "bg-primary/10 text-primary border border-primary/20"
           : "text-muted-foreground hover:text-foreground hover:bg-white/5"
       }`}>
         <Icon className={`w-5 h-5 ${isActive ? "text-primary" : "text-muted-foreground group-hover:text-foreground"}`} />
@@ -34,14 +34,15 @@ export default function Layout({ children }: { children: React.ReactNode }) {
             <Zap className="w-5 h-5 text-primary" />
           </div>
           <div>
-            <h1 className="font-mono font-bold text-lg tracking-wider text-foreground">QEL<span className="text-primary">.OS</span></h1>
-            <p className="text-[10px] text-muted-foreground uppercase tracking-widest">Quantum Ops</p>
+            <h1 className="font-mono font-bold text-lg tracking-wider text-foreground">QEL<span className="text-primary">.Console</span></h1>
+            <p className="text-[10px] text-muted-foreground uppercase tracking-widest">Reference integration</p>
           </div>
         </div>
       </div>
 
-      <nav className="flex-1 p-4 space-y-2">
+      <nav className="flex-1 p-4 space-y-2 overflow-y-auto">
         <NavItem href="/dashboard" icon={LayoutDashboard} label="Mission Control" />
+        <NavItem href="/qel-pilot" icon={FileCheck2} label="QEL v0.1 Pilot" />
         <NavItem href="/workspace" icon={Briefcase} label="Workspace" />
         <NavItem href="/briefing" icon={FileCode} label="Platform Briefing" />
         <NavItem href="/devkit" icon={Cpu} label="Dev Framework" />
@@ -67,12 +68,10 @@ export default function Layout({ children }: { children: React.ReactNode }) {
 
   return (
     <div className="min-h-screen bg-background text-foreground flex overflow-hidden">
-      {/* Desktop Sidebar */}
       <aside className="hidden md:block w-64 h-screen fixed left-0 top-0 z-20">
         <NavContent />
       </aside>
 
-      {/* Mobile Sidebar */}
       <div className="md:hidden fixed top-4 left-4 z-50">
         <Sheet open={isOpen} onOpenChange={setIsOpen}>
           <SheetTrigger asChild>
@@ -86,7 +85,6 @@ export default function Layout({ children }: { children: React.ReactNode }) {
         </Sheet>
       </div>
 
-      {/* Main Content */}
       <main className="flex-1 md:ml-64 min-h-screen relative overflow-y-auto">
         <div className="absolute inset-0 z-0 bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] from-primary/5 via-background to-background pointer-events-none" />
         <div className="relative z-10 p-6 md:p-12 max-w-7xl mx-auto space-y-8 animate-in fade-in slide-in-from-bottom-4 duration-500">

--- a/client/src/pages/qel-pilot.tsx
+++ b/client/src/pages/qel-pilot.tsx
@@ -2,13 +2,29 @@ import Layout from "@/components/layout";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { useQuery } from "@tanstack/react-query";
-import { CheckCircle2, FileCheck2, GitBranch, ShieldAlert } from "lucide-react";
+import { CheckCircle2, FileCheck2, GitBranch, ShieldAlert, ShieldCheck } from "lucide-react";
+
+interface ProductReceivedActivation {
+  ready: boolean;
+  enabled: boolean;
+  missing: string[];
+  warehouseNodeCount: number;
+  licensedOperatorCount: number;
+  configurationError: string | null;
+}
 
 interface QelStatus {
   language: string;
   specVersion: string;
   frozenSnapshot: string;
   validation: { implementation: string; commands: string[] };
+  pilot: {
+    liveActivation: {
+      activeEvent: string;
+      otherEventsEnabled: boolean;
+      productReceived: ProductReceivedActivation;
+    };
+  };
 }
 
 interface QelExpression {
@@ -29,6 +45,7 @@ interface PilotResponse {
 export default function QelPilot() {
   const statusQuery = useQuery<QelStatus>({ queryKey: ["/api/qel/status"] });
   const eventsQuery = useQuery<PilotResponse>({ queryKey: ["/api/qel/pilot/voi/events"] });
+  const productReceived = statusQuery.data?.pilot.liveActivation.productReceived;
 
   return (
     <Layout>
@@ -40,7 +57,7 @@ export default function QelPilot() {
             </div>
             <div>
               <h1 className="text-3xl font-bold tracking-tight">QEL v0.1 Pilot</h1>
-              <p className="text-muted-foreground">Read-only connection to the extracted specification and VOI conformance fixtures.</p>
+              <p className="text-muted-foreground">Read-only status for the extracted specification, VOI fixtures, and controlled Product Received gate.</p>
             </div>
           </div>
         </header>
@@ -51,7 +68,7 @@ export default function QelPilot() {
             <div>
               <div className="font-semibold">Claim boundary</div>
               <p className="text-sm text-muted-foreground">
-                A valid expression is a signed, integrity-protected claim. It is not automatically a true fact, legal determination, or accepted institutional outcome.
+                A valid expression is an integrity-protected claim. It is not automatically a true fact, legal determination, or accepted institutional outcome.
               </p>
             </div>
           </CardContent>
@@ -62,7 +79,7 @@ export default function QelPilot() {
         ) : statusQuery.error || !statusQuery.data ? (
           <Card><CardContent className="p-6 text-destructive">QEL status endpoint is unavailable.</CardContent></Card>
         ) : (
-          <div className="grid gap-4 md:grid-cols-3">
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
             <Card>
               <CardHeader><CardDescription>Specification</CardDescription><CardTitle>{statusQuery.data.specVersion}</CardTitle></CardHeader>
               <CardContent className="text-sm text-muted-foreground">{statusQuery.data.language}</CardContent>
@@ -77,13 +94,29 @@ export default function QelPilot() {
                 {statusQuery.data.validation.commands.map((command) => <Badge key={command} variant="outline">{command}</Badge>)}
               </CardContent>
             </Card>
+            <Card className={productReceived?.ready ? "border-emerald-500/40" : "border-amber-500/30"}>
+              <CardHeader>
+                <CardDescription>Live activation</CardDescription>
+                <CardTitle className="flex items-center gap-2 text-base">
+                  {productReceived?.ready ? <ShieldCheck className="h-4 w-4 text-emerald-500" /> : <ShieldAlert className="h-4 w-4 text-amber-500" />}
+                  Product Received
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2 text-xs text-muted-foreground">
+                <Badge variant={productReceived?.ready ? "default" : "outline"}>{productReceived?.ready ? "READY" : "DISABLED / INCOMPLETE"}</Badge>
+                <div>{productReceived?.warehouseNodeCount ?? 0} warehouse node(s)</div>
+                <div>{productReceived?.licensedOperatorCount ?? 0} licensed operator(s)</div>
+                {productReceived?.configurationError ? <div className="text-destructive">{productReceived.configurationError}</div> : null}
+                {(productReceived?.missing ?? []).map((item) => <div key={item} className="font-mono">Missing: {item}</div>)}
+              </CardContent>
+            </Card>
           </div>
         )}
 
         <Card>
           <CardHeader>
             <CardTitle>VOI five-event chain</CardTitle>
-            <CardDescription>Canonical test fixtures served from `qel-spec/examples/voi`.</CardDescription>
+            <CardDescription>Canonical test fixtures served from `qel-spec/examples/voi`. Only Product Received has a controlled live admission path.</CardDescription>
           </CardHeader>
           <CardContent>
             {eventsQuery.isLoading ? (

--- a/client/src/pages/qel-pilot.tsx
+++ b/client/src/pages/qel-pilot.tsx
@@ -1,0 +1,122 @@
+import Layout from "@/components/layout";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { useQuery } from "@tanstack/react-query";
+import { CheckCircle2, FileCheck2, GitBranch, ShieldAlert } from "lucide-react";
+
+interface QelStatus {
+  language: string;
+  specVersion: string;
+  frozenSnapshot: string;
+  validation: { implementation: string; commands: string[] };
+}
+
+interface QelExpression {
+  id: string;
+  type: string;
+  status: string;
+  subject: { id: string; type: string };
+  transition?: { from: string | null; to: string };
+  time: { occurred_at: string; issued_at: string };
+  proof: Array<{ type: string; payload_digest: string }>;
+}
+
+interface PilotResponse {
+  count: number;
+  expressions: QelExpression[];
+}
+
+export default function QelPilot() {
+  const statusQuery = useQuery<QelStatus>({ queryKey: ["/api/qel/status"] });
+  const eventsQuery = useQuery<PilotResponse>({ queryKey: ["/api/qel/pilot/voi/events"] });
+
+  return (
+    <Layout>
+      <div className="space-y-6">
+        <header>
+          <div className="flex items-center gap-3">
+            <div className="rounded-lg border border-primary/30 bg-primary/10 p-2">
+              <FileCheck2 className="h-6 w-6 text-primary" />
+            </div>
+            <div>
+              <h1 className="text-3xl font-bold tracking-tight">QEL v0.1 Pilot</h1>
+              <p className="text-muted-foreground">Read-only connection to the extracted specification and VOI conformance fixtures.</p>
+            </div>
+          </div>
+        </header>
+
+        <Card className="border-amber-500/30 bg-amber-500/5">
+          <CardContent className="flex items-start gap-3 p-4">
+            <ShieldAlert className="mt-0.5 h-5 w-5 text-amber-500" />
+            <div>
+              <div className="font-semibold">Claim boundary</div>
+              <p className="text-sm text-muted-foreground">
+                A valid expression is a signed, integrity-protected claim. It is not automatically a true fact, legal determination, or accepted institutional outcome.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
+        {statusQuery.isLoading ? (
+          <Card><CardContent className="p-6 text-muted-foreground">Loading QEL status…</CardContent></Card>
+        ) : statusQuery.error || !statusQuery.data ? (
+          <Card><CardContent className="p-6 text-destructive">QEL status endpoint is unavailable.</CardContent></Card>
+        ) : (
+          <div className="grid gap-4 md:grid-cols-3">
+            <Card>
+              <CardHeader><CardDescription>Specification</CardDescription><CardTitle>{statusQuery.data.specVersion}</CardTitle></CardHeader>
+              <CardContent className="text-sm text-muted-foreground">{statusQuery.data.language}</CardContent>
+            </Card>
+            <Card>
+              <CardHeader><CardDescription>Frozen source</CardDescription><CardTitle className="flex items-center gap-2 text-base"><GitBranch className="h-4 w-4" /> Snapshot preserved</CardTitle></CardHeader>
+              <CardContent className="break-all font-mono text-xs text-muted-foreground">{statusQuery.data.frozenSnapshot}</CardContent>
+            </Card>
+            <Card>
+              <CardHeader><CardDescription>Reference core</CardDescription><CardTitle className="text-base">{statusQuery.data.validation.implementation}</CardTitle></CardHeader>
+              <CardContent className="flex flex-wrap gap-2">
+                {statusQuery.data.validation.commands.map((command) => <Badge key={command} variant="outline">{command}</Badge>)}
+              </CardContent>
+            </Card>
+          </div>
+        )}
+
+        <Card>
+          <CardHeader>
+            <CardTitle>VOI five-event chain</CardTitle>
+            <CardDescription>Canonical test fixtures served from `qel-spec/examples/voi`.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {eventsQuery.isLoading ? (
+              <p className="text-sm text-muted-foreground">Loading expressions…</p>
+            ) : eventsQuery.error || !eventsQuery.data ? (
+              <p className="text-sm text-destructive">Pilot expressions are unavailable.</p>
+            ) : (
+              <div className="space-y-3">
+                {eventsQuery.data.expressions.map((expression, index) => (
+                  <div key={expression.id} className="rounded-lg border border-border bg-secondary/10 p-4">
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div className="flex items-start gap-3">
+                        <div className="mt-0.5 flex h-7 w-7 items-center justify-center rounded-full border border-primary/30 bg-primary/10 font-mono text-xs text-primary">{index + 1}</div>
+                        <div>
+                          <div className="font-semibold">{expression.type}</div>
+                          <div className="mt-1 font-mono text-xs text-muted-foreground">{expression.id}</div>
+                        </div>
+                      </div>
+                      <Badge className="gap-1"><CheckCircle2 className="h-3 w-3" /> {expression.status}</Badge>
+                    </div>
+                    <div className="mt-4 grid gap-3 text-xs md:grid-cols-4">
+                      <div><span className="text-muted-foreground">Subject</span><div className="mt-1 break-all font-mono">{expression.subject.id}</div></div>
+                      <div><span className="text-muted-foreground">Transition</span><div className="mt-1 font-mono">{expression.transition?.from ?? "∅"} → {expression.transition?.to ?? "—"}</div></div>
+                      <div><span className="text-muted-foreground">Occurred</span><div className="mt-1 font-mono">{expression.time.occurred_at}</div></div>
+                      <div><span className="text-muted-foreground">Digest</span><div className="mt-1 truncate font-mono" title={expression.proof[0]?.payload_digest}>{expression.proof[0]?.payload_digest}</div></div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </Layout>
+  );
+}

--- a/docs/PRODUCT_RECEIVED_ACCEPTANCE_RECORD.md
+++ b/docs/PRODUCT_RECEIVED_ACCEPTANCE_RECORD.md
@@ -1,0 +1,48 @@
+# Product Received Acceptance Record
+
+Complete this record outside the public repository for the first controlled VOI GRN. Commit only a redacted outcome summary after approval.
+
+## Controlled identifiers
+
+- Deployment version:
+- Warehouse node:
+- Operator DigitalMe ID (pseudonymous reference only):
+- EmpireOS licence reference:
+- Source system:
+- GRN reference:
+- Request digest:
+- Idempotency key reference:
+
+## Admission results
+
+- [ ] Readiness endpoint returned `ready: true`.
+- [ ] Request schema validation passed.
+- [ ] Warehouse allowlist check passed.
+- [ ] Operator/licence allowlist check passed.
+- [ ] Initial submission returned HTTP 201.
+- [ ] RiverOS receipt status was `accepted`.
+- [ ] RiverOS expression digest matched the submitted expression digest.
+- [ ] Identical replay returned the original accepted result.
+- [ ] Changed payload with the same idempotency key returned HTTP 409.
+- [ ] Unlicensed operator test returned HTTP 403.
+- [ ] Non-allowlisted warehouse test returned HTTP 403.
+- [ ] Evidence was independently retrieved and its digest matched.
+
+## Result
+
+- Controlled run status: PASS / FAIL
+- Expression ID:
+- Expression digest:
+- RiverOS receipt ID:
+- RiverOS evidence URI:
+- Reviewer:
+- Review date:
+- Exceptions or disputes:
+
+## Activation decision
+
+- [ ] Keep Product Received enabled for the controlled node/operator pair.
+- [ ] Disable Product Received and investigate.
+- [ ] Authorize design work for Inventory Transferred.
+
+The final checkbox must remain unchecked unless every admission result above passes and the operational reviewer accepts the evidence package.

--- a/docs/QEL_V0_1_EXTRACTION.md
+++ b/docs/QEL_V0_1_EXTRACTION.md
@@ -1,0 +1,48 @@
+# QEL v0.1 Extraction Record
+
+## Freeze
+
+The original React/Express prototype is preserved at `archive/qel-console-2026-07-21`, created from main commit `0301a0e1c4048e3c19b89d3d841d1aa067c0e09a`.
+
+The snapshot preserves the historical console, mock dashboards, attached design material, and the former Quantum Vision narrative without treating those assets as the language specification.
+
+## Separation of concerns
+
+| Layer | Responsibility |
+|---|---|
+| `qel-spec` | Normative meaning and conformance vectors |
+| `qel-core` | Reference validation, canonicalization, hashing, and CLI behavior |
+| QEL console | Read-only inspection and operational integration |
+| Synnergyze | Workflow and execution orchestration |
+| DigitalMe | Identity, consent, and local signing control |
+| EmpireOS | Licence and authority registry |
+| Quantum Arc | Physical/digital operating boundary |
+| RiverOS | Evidence custody, receipts, lineage, and replay |
+| VSR | Discovery and cross-entity routing |
+| Warden | Policy evaluation, challenge, exception, and escalation |
+
+## Non-negotiable semantic boundary
+
+QEL records claims about reality. Signature verification demonstrates issuer authentication and content integrity; it does not by itself prove the claim is true.
+
+Every consumer must distinguish:
+
+1. schema validity;
+2. canonical integrity;
+3. proof validity;
+4. authority validity;
+5. evidentiary sufficiency;
+6. institutional acceptance;
+7. dispute, correction, revocation, and supersession state.
+
+## v0.1 pilot boundary
+
+The first conformance pilot is limited to five events:
+
+1. product received;
+2. inventory transferred;
+3. product sold;
+4. product returned;
+5. payment settled.
+
+The fixtures are pseudonymous and contain no production credentials or personal data.

--- a/docs/VOI_PRODUCT_RECEIVED_RUNBOOK.md
+++ b/docs/VOI_PRODUCT_RECEIVED_RUNBOOK.md
@@ -1,0 +1,148 @@
+# VOI Product Received — Controlled Activation Runbook
+
+Status: implementation gate for the first live QEL event only.
+
+This runbook does not enable Inventory Transferred, Product Sold, Product Returned, or Payment Settled. Those event types remain fixtures until Product Received completes an end-to-end controlled run.
+
+## 1. Acceptance boundary
+
+A successful API response means:
+
+1. the request matched the Product Received input schema;
+2. the warehouse node was explicitly allowlisted;
+3. the operator and EmpireOS licence reference matched the configured allowlist;
+4. the idempotency key was not reused for a different request;
+5. RiverOS returned an accepted receipt bound to the exact expression digest.
+
+It does not by itself establish that the physical goods, quantities, documents, or legal claims are factually correct. Independent inspection and later attestations may still challenge or supersede the expression.
+
+## 2. Required controlled inputs
+
+Before activation, obtain and verify exactly one instance of each:
+
+- VOI GRN ID and GRN document;
+- GRN SHA-256 digest;
+- one warehouse/Quantum Arc node identifier;
+- one DigitalMe operator identifier;
+- one EmpireOS warehouse-receiving licence reference;
+- one purchase order identifier;
+- one supplier identifier;
+- one product batch, SKU, style code, quantity, and receiving timestamp;
+- at least one additional receiving evidence artifact and digest;
+- one RiverOS receipt endpoint with service credentials.
+
+Do not place real secrets, personal identifiers, bank identifiers, or confidential documents in the repository.
+
+## 3. Configuration
+
+Use a secret manager or deployment environment. `.env.qel.example` is non-operational and contains placeholders only.
+
+Required variables:
+
+```text
+QEL_PRODUCT_RECEIVED_ENABLED=true
+QEL_INGEST_API_KEY=<secret>
+QEL_WAREHOUSE_NODES=<comma-separated node IDs>
+QEL_PRODUCT_RECEIVED_LICENSES=<JSON operator-to-licence mapping>
+RIVEROS_RECEIPT_ENDPOINT=<HTTPS endpoint>
+RIVEROS_API_KEY=<service secret, when required>
+```
+
+The service reports readiness at:
+
+```text
+GET /api/qel/pilot/voi/product-received/status
+```
+
+`ready` must be `true` before any controlled write.
+
+## 4. Preflight validation
+
+Copy `qel-spec/examples/voi/live/product-received-request.template.json` outside the repository and replace every placeholder.
+
+Run schema and authority validation without creating an expression or requesting a RiverOS receipt:
+
+```bash
+curl --fail-with-body \
+  -H 'Content-Type: application/json' \
+  --data-binary @product-received-request.json \
+  https://<console-host>/api/qel/pilot/voi/product-received/validate
+```
+
+Expected result:
+
+```json
+{
+  "valid": true,
+  "schemaValid": true,
+  "operationalAuthorityValid": true,
+  "errors": [],
+  "requestDigest": "sha256:..."
+}
+```
+
+## 5. Controlled submission
+
+Use a unique idempotency key derived from the source system and GRN, without embedding confidential data. Example pattern:
+
+```text
+logic-erp:product-received:<controlled-random-id>
+```
+
+Submit:
+
+```bash
+curl --fail-with-body \
+  -H 'Content-Type: application/json' \
+  -H 'X-QEL-Ingest-Key: <secret>' \
+  -H 'Idempotency-Key: <unique-key>' \
+  --data-binary @product-received-request.json \
+  https://<console-host>/api/qel/pilot/voi/product-received
+```
+
+The service returns HTTP `201` only after RiverOS accepts the expression and returns a matching digest receipt.
+
+## 6. Evidence to retain
+
+Retain outside the application log:
+
+- source GRN and its calculated digest;
+- submitted request digest;
+- generated QEL expression ID and digest;
+- RiverOS receipt ID, URI, timestamp, and digest;
+- deployment version and configuration identifiers;
+- operator and licence verification record;
+- HTTP status and response body with secrets removed.
+
+## 7. Idempotency
+
+The console keeps an in-process replay cache for immediate duplicate protection. It is not the durable source of idempotency.
+
+RiverOS must enforce the same `Idempotency-Key` durably across process restarts. Reusing a key for different content must fail. Reusing it for identical content may return the original receipt.
+
+## 8. Failure and rollback
+
+Set:
+
+```text
+QEL_PRODUCT_RECEIVED_ENABLED=false
+```
+
+and restart/redeploy the service to disable writes immediately.
+
+A failed or disputed physical receipt must not be edited in place. Issue a later QEL correction, dispute, rejection, or supersession expression after those lifecycle operations are implemented.
+
+## 9. Exit criteria
+
+Product Received is considered proven for the pilot only when:
+
+1. one real controlled GRN passes preflight;
+2. the write endpoint returns one RiverOS-bound receipt;
+3. the same idempotency key and same request replay safely;
+4. the same key with changed content is rejected;
+5. the expression and evidence can be independently retrieved and matched by digest;
+6. an operator other than the allowlisted operator is rejected;
+7. a warehouse other than the allowlisted node is rejected;
+8. the operational team signs off on the evidence package.
+
+Only after all eight conditions pass should Inventory Transferred be designed for live activation.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "tsx script/build.ts",
     "start": "NODE_ENV=production node dist/index.cjs",
     "check": "tsc",
+    "test:qel-ingest": "tsx --test server/qel/product-received.test.ts",
     "db:push": "drizzle-kit push"
   },
   "dependencies": {

--- a/qel-core/README.md
+++ b/qel-core/README.md
@@ -1,0 +1,14 @@
+# qel-core
+
+Python reference implementation for QEL v0.1 draft.
+
+Commands:
+
+```bash
+qel validate expression.json
+qel canonicalize expression.json
+qel hash expression.json
+qel verify-digest expression.json
+```
+
+`verify-digest` checks only whether each declared `payload_digest` matches the canonical expression payload. It does not verify cryptographic signatures or factual truth.

--- a/qel-core/pyproject.toml
+++ b/qel-core/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "qel-core"
+version = "0.1.0.dev0"
+description = "Reference validator and canonicalizer for Quantum Expression Language"
+requires-python = ">=3.11"
+dependencies = ["jsonschema[format]>=4.23"]
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0"]
+
+[project.scripts]
+qel = "qel_core.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/qel-core/src/qel_core/__init__.py
+++ b/qel-core/src/qel_core/__init__.py
@@ -1,0 +1,13 @@
+"""QEL v0.1 draft reference implementation."""
+
+from .canonicalize import canonical_bytes, canonical_json, payload_digest
+from .validate import ValidationResult, load_schema, validate_expression
+
+__all__ = [
+    "ValidationResult",
+    "canonical_bytes",
+    "canonical_json",
+    "load_schema",
+    "payload_digest",
+    "validate_expression",
+]

--- a/qel-core/src/qel_core/canonicalize.py
+++ b/qel-core/src/qel_core/canonicalize.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from typing import Any
+
+
+def _payload_without_proof(expression: dict[str, Any]) -> dict[str, Any]:
+    payload = deepcopy(expression)
+    payload.pop("proof", None)
+    return payload
+
+
+def canonical_json(expression: dict[str, Any], *, include_proof: bool = True) -> str:
+    value = expression if include_proof else _payload_without_proof(expression)
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def canonical_bytes(expression: dict[str, Any], *, include_proof: bool = True) -> bytes:
+    return canonical_json(expression, include_proof=include_proof).encode("utf-8")
+
+
+def payload_digest(expression: dict[str, Any]) -> str:
+    digest = hashlib.sha256(canonical_bytes(expression, include_proof=False)).hexdigest()
+    return f"sha256:{digest}"

--- a/qel-core/src/qel_core/cli.py
+++ b/qel-core/src/qel_core/cli.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from .canonicalize import canonical_json, payload_digest
+from .validate import load_schema, validate_expression
+
+
+def read_expression(path: str) -> dict[str, Any]:
+    with Path(path).open("r", encoding="utf-8") as handle:
+        value = json.load(handle)
+    if not isinstance(value, dict):
+        raise ValueError("QEL expression must be a JSON object")
+    return value
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(prog="qel")
+    parser.add_argument("command", choices=["validate", "canonicalize", "hash", "verify-digest"])
+    parser.add_argument("file")
+    parser.add_argument("--schema")
+    args = parser.parse_args()
+
+    expression = read_expression(args.file)
+
+    if args.command == "canonicalize":
+        print(canonical_json(expression))
+        return 0
+
+    if args.command == "hash":
+        print(payload_digest(expression))
+        return 0
+
+    result = validate_expression(expression, load_schema(args.schema))
+
+    if args.command == "verify-digest":
+        print("valid" if result.digest_matches else "invalid")
+        return 0 if result.digest_matches else 1
+
+    if result.valid:
+        print("valid")
+        return 0
+
+    print("invalid")
+    for error in result.errors:
+        print(f"- {error}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/qel-core/src/qel_core/validate.py
+++ b/qel-core/src/qel_core/validate.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+from .canonicalize import payload_digest
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    valid: bool
+    errors: tuple[str, ...]
+    digest_matches: bool
+
+
+def default_schema_path() -> Path:
+    return Path(__file__).resolve().parents[3] / "qel-spec" / "core" / "qel-core.schema.json"
+
+
+def load_schema(path: str | Path | None = None) -> dict[str, Any]:
+    schema_path = Path(path) if path else default_schema_path()
+    with schema_path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def validate_expression(expression: dict[str, Any], schema: dict[str, Any]) -> ValidationResult:
+    validator = Draft202012Validator(schema, format_checker=FormatChecker())
+    errors = tuple(
+        f"{'.'.join(str(part) for part in error.absolute_path) or '<root>'}: {error.message}"
+        for error in sorted(validator.iter_errors(expression), key=lambda item: list(item.absolute_path))
+    )
+
+    expected = payload_digest(expression)
+    proofs = expression.get("proof", [])
+    digest_matches = bool(proofs) and all(proof.get("payload_digest") == expected for proof in proofs)
+
+    if not digest_matches:
+        errors = (*errors, "proof: payload_digest does not match canonical payload")
+
+    return ValidationResult(valid=not errors, errors=errors, digest_matches=digest_matches)

--- a/qel-core/tests/test_conformance.py
+++ b/qel-core/tests/test_conformance.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from qel_core.canonicalize import canonical_json, payload_digest
+from qel_core.validate import load_schema, validate_expression
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = ROOT / "qel-spec"
+
+
+def load(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_voi_pilot_vectors_are_valid_and_digest_stable():
+    schema = load_schema(SPEC / "core" / "qel-core.schema.json")
+    files = sorted((SPEC / "examples" / "voi").glob("*.json"))
+    assert len(files) == 5
+
+    for path in files:
+        expression = load(path)
+        result = validate_expression(expression, schema)
+        assert result.valid, f"{path.name}: {result.errors}"
+        assert canonical_json(expression) == canonical_json(load(path))
+        assert expression["proof"][0]["payload_digest"] == payload_digest(expression)
+
+
+def test_invalid_vectors_fail():
+    schema = load_schema(SPEC / "core" / "qel-core.schema.json")
+    files = sorted((SPEC / "tests" / "invalid").glob("*.json"))
+    assert files
+    for path in files:
+        assert not validate_expression(load(path), schema).valid, path.name

--- a/qel-spec/CHARTER.md
+++ b/qel-spec/CHARTER.md
@@ -1,0 +1,33 @@
+# QEL Charter
+
+## 1. Purpose
+
+Quantum Expression Language provides a neutral and durable semantic format for expressing claims concerning observations, actions, states, authorizations, attestations, and institutional consequences.
+
+## 2. Claim, not fact
+
+A QEL expression is a signed claim about reality. Structural validity, canonical integrity, or signature validity must never be represented as automatic proof that the asserted occurrence is factually true, legally valid, or institutionally accepted.
+
+## 3. Neutrality
+
+No vendor, product, storage system, ledger, cloud, or implementation may redefine QEL Core semantics.
+
+## 4. Authority and consent
+
+Expressions that rely on authority or consent must identify the applicable basis and scope. Missing, expired, revoked, disputed, or out-of-scope authority must remain visible to consumers.
+
+## 5. Evidence and provenance
+
+Expressions must support evidence references, prior-state linkage, independent attestations, correction, revocation, and supersession without erasing historical records.
+
+## 6. Privacy and minimization
+
+QEL implementations must minimize personal and device data. Sensitive evidence should normally remain outside the expression and be referenced by digest and controlled locator.
+
+## 7. Additive evolution
+
+Published meanings may be deprecated but not silently repurposed. Breaking semantic changes require a new major version.
+
+## 8. Independent implementation
+
+Any party may implement QEL provided that the implementation does not claim normative authority beyond the published specification and conformance vectors.

--- a/qel-spec/GOVERNANCE.md
+++ b/qel-spec/GOVERNANCE.md
@@ -1,0 +1,23 @@
+# QEL Governance — Draft
+
+## Normative authority
+
+The specification, versioned schema, canonicalization rules, and conformance vectors collectively define QEL Core behavior. Product documentation and console copy are non-normative.
+
+## Change classes
+
+- **Editorial:** wording corrections with no semantic effect.
+- **Compatible:** optional fields, new extension points, or additional test vectors.
+- **Breaking:** changed required fields, changed canonical meaning, changed validation outcome, or changed cryptographic input.
+
+## Decision record
+
+Every compatible or breaking change requires an RFC containing motivation, security and privacy impact, migration behavior, test-vector changes, and an explicit decision record.
+
+## Conflict rule
+
+When prose, schema, examples, and reference code disagree, the inconsistency must block release. No single artifact silently overrides the others.
+
+## Stewardship limitation
+
+The steward maintains the language and publishes decisions. It does not certify the factual truth, legality, or admissibility of individual expressions.

--- a/qel-spec/README.md
+++ b/qel-spec/README.md
@@ -1,0 +1,20 @@
+# QEL Specification v0.1
+
+This directory is the extracted normative draft for Quantum Expression Language.
+
+QEL expresses signed, versioned claims about occurrences and state transitions. It does not execute business logic, determine legal validity, or guarantee factual truth.
+
+## Normative documents
+
+- `CHARTER.md`
+- `GOVERNANCE.md`
+- `VERSIONING.md`
+- `core/claim-semantics.md`
+- `core/canonicalization.md`
+- `core/qel-core.schema.json`
+
+## Conformance
+
+Files under `examples/` and `tests/` are machine-readable test vectors. Valid examples must pass the canonical schema and the reference implementation. Invalid examples must fail for the documented reason.
+
+Status: **v0.1.0-draft — not ratified**.

--- a/qel-spec/VERSIONING.md
+++ b/qel-spec/VERSIONING.md
@@ -1,0 +1,12 @@
+# QEL Versioning
+
+QEL uses semantic versioning for the specification and a mandatory `qel_version` field in every expression.
+
+## Compatibility
+
+- Unknown major versions must be rejected.
+- Newer minor versions may be accepted only when all required semantics are understood.
+- Patch versions may clarify text and add test coverage without changing validation behavior.
+- Deprecated fields remain parseable for the support period declared by the major version.
+
+The initial draft version is `0.1.0` and is not yet ratified for legal or production reliance.

--- a/qel-spec/core/canonicalization.md
+++ b/qel-spec/core/canonicalization.md
@@ -1,0 +1,13 @@
+# QEL Canonicalization
+
+QEL v0.1 canonical JSON is UTF-8 JSON with:
+
+1. object keys sorted lexicographically;
+2. no insignificant whitespace;
+3. Unicode emitted directly rather than ASCII escaped;
+4. JSON numbers restricted by the schema to interoperable integer or decimal forms;
+5. a single trailing newline excluded from the digest input.
+
+The reference implementation uses Python's deterministic JSON encoder for v0.1 draft conformance. Before ratification, QEL must adopt a formally specified cross-language canonicalization profile such as RFC 8785 or an equivalent reviewed standard.
+
+The expression digest is SHA-256 over the canonical UTF-8 bytes after removing the `proof` field. Proofs therefore secure the semantic payload and may be replaced or extended without changing the payload digest.

--- a/qel-spec/core/claim-semantics.md
+++ b/qel-spec/core/claim-semantics.md
@@ -1,0 +1,57 @@
+# QEL Claim Semantics
+
+## Expression model
+
+A QEL expression is an immutable statement issued by an identifiable issuer. It may describe an observation, action, state transition, authorization, or attestation.
+
+## Required distinction of roles
+
+- `issuer`: entity issuing and signing the expression.
+- `actor`: entity that performed the described action, when applicable.
+- `subject`: entity or object about which the claim is made.
+- `observer`: entity or device that witnessed or measured the occurrence, when applicable.
+- `beneficiary`: entity receiving the entitlement or outcome, when applicable.
+
+An issuer may occupy another role, but the roles must not be silently conflated.
+
+## Lifecycle
+
+Core lifecycle states are:
+
+- `proposed`
+- `asserted`
+- `attested`
+- `verified`
+- `accepted`
+- `disputed`
+- `corrected`
+- `revoked`
+- `superseded`
+- `rejected`
+
+`verified` means that defined verification procedures completed; it does not mean universal factual truth.
+
+## Time
+
+- `occurred_at`: time of the described real-world occurrence.
+- `observed_at`: time the occurrence was measured or witnessed.
+- `issued_at`: time the expression was created.
+- `effective_from` and `effective_until`: optional legal or operational validity interval.
+
+## Relationships
+
+Expressions may be connected using `authorizes`, `caused_by`, `attests`, `corrects`, `disputes`, `revokes`, and `supersedes`.
+
+Historical expressions are never mutated to hide correction or revocation. A new expression records the new institutional state.
+
+## Validation layers
+
+A consumer must evaluate separately:
+
+1. schema validity;
+2. canonicalization and digest integrity;
+3. proof verification;
+4. authority scope and validity;
+5. evidence sufficiency;
+6. policy acceptance;
+7. dispute and supersession state.

--- a/qel-spec/core/qel-core.schema.json
+++ b/qel-spec/core/qel-core.schema.json
@@ -1,0 +1,143 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://qel.example/spec/0.1/qel-core.schema.json",
+  "title": "Quantum Expression Language Core Expression",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "qel_version", "id", "kind", "type", "status", "issuer",
+    "subject", "place", "time", "authority", "consent",
+    "evidence", "relationships", "payload", "proof"
+  ],
+  "properties": {
+    "qel_version": { "const": "0.1.0" },
+    "id": { "type": "string", "pattern": "^urn:qel:expression:[A-Za-z0-9._:-]+$" },
+    "kind": { "enum": ["observation", "action", "state", "authorization", "attestation"] },
+    "type": { "type": "string", "pattern": "^[a-z0-9]+(?:[.-][a-z0-9]+)*\\.v[1-9][0-9]*$" },
+    "status": {
+      "enum": ["proposed", "asserted", "attested", "verified", "accepted", "disputed", "corrected", "revoked", "superseded", "rejected"]
+    },
+    "issuer": { "$ref": "#/$defs/party" },
+    "actor": { "$ref": "#/$defs/party" },
+    "observer": { "$ref": "#/$defs/party" },
+    "beneficiary": { "$ref": "#/$defs/party" },
+    "subject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "type"],
+      "properties": {
+        "id": { "type": "string", "minLength": 3 },
+        "type": { "type": "string", "minLength": 1 }
+      }
+    },
+    "transition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["from", "to"],
+      "properties": {
+        "from": { "type": ["string", "null"] },
+        "to": { "type": "string", "minLength": 1 }
+      }
+    },
+    "place": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["node", "jurisdiction"],
+      "properties": {
+        "node": { "type": "string", "minLength": 3 },
+        "jurisdiction": { "type": "string", "pattern": "^[A-Z]{2}(?:-[A-Z0-9]{1,3})?$" }
+      }
+    },
+    "time": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["occurred_at", "issued_at"],
+      "properties": {
+        "occurred_at": { "type": "string", "format": "date-time" },
+        "observed_at": { "type": "string", "format": "date-time" },
+        "issued_at": { "type": "string", "format": "date-time" },
+        "effective_from": { "type": "string", "format": "date-time" },
+        "effective_until": { "type": "string", "format": "date-time" }
+      }
+    },
+    "authority": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type", "reference", "scope"],
+        "properties": {
+          "type": { "type": "string", "minLength": 1 },
+          "reference": { "type": "string", "minLength": 3 },
+          "scope": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } }
+        }
+      }
+    },
+    "consent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "basis"],
+      "properties": {
+        "status": { "enum": ["granted", "denied", "revoked", "not-applicable", "unknown"] },
+        "basis": { "type": "string", "minLength": 1 },
+        "reference": { "type": "string" }
+      }
+    },
+    "evidence": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type", "digest", "location"],
+        "properties": {
+          "type": { "type": "string", "minLength": 1 },
+          "digest": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+          "location": { "type": "string", "minLength": 3 },
+          "media_type": { "type": "string" }
+        }
+      }
+    },
+    "relationships": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["relation", "expression"],
+        "properties": {
+          "relation": { "enum": ["authorizes", "caused_by", "attests", "corrects", "disputes", "revokes", "supersedes"] },
+          "expression": { "type": "string", "pattern": "^urn:qel:expression:" }
+        }
+      }
+    },
+    "payload": { "type": "object" },
+    "proof": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type", "verification_method", "created", "payload_digest", "proof_value"],
+        "properties": {
+          "type": { "enum": ["DataIntegrityProof", "DetachedJws", "MockProof"] },
+          "verification_method": { "type": "string", "minLength": 3 },
+          "created": { "type": "string", "format": "date-time" },
+          "payload_digest": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+          "proof_value": { "type": "string", "minLength": 3 }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "party": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "role"],
+      "properties": {
+        "id": { "type": "string", "minLength": 3 },
+        "role": { "type": "string", "minLength": 1 }
+      }
+    }
+  }
+}

--- a/qel-spec/examples/voi/001-product-received.json
+++ b/qel-spec/examples/voi/001-product-received.json
@@ -1,0 +1,44 @@
+{
+  "qel_version": "0.1.0",
+  "id": "urn:qel:expression:voi-pilot-001-product-received",
+  "kind": "observation",
+  "type": "org.virtualsilkroad.inventory.product-received.v1",
+  "status": "attested",
+  "issuer": { "id": "did:example:voi-pilot-operator", "role": "warehouse-receiving-authority" },
+  "actor": { "id": "did:example:voi-pilot-operator", "role": "receiving-operator" },
+  "subject": { "id": "urn:voi:batch:aw26-00421", "type": "product-batch" },
+  "transition": { "from": "in-transit", "to": "received" },
+  "place": { "node": "urn:vsr:node:voi-pilot-bangalore-001", "jurisdiction": "IN-KA" },
+  "time": {
+    "occurred_at": "2026-07-21T10:30:00+05:30",
+    "observed_at": "2026-07-21T10:30:00+05:30",
+    "issued_at": "2026-07-21T10:30:00+05:30"
+  },
+  "authority": [{
+    "type": "warehouse-receiving-mandate",
+    "reference": "urn:empireos:license:voi-warehouse-receiving-v1",
+    "scope": ["receive-product", "record-custody"]
+  }],
+  "consent": { "status": "not-applicable", "basis": "commercial-and-operational-record" },
+  "evidence": [{
+    "type": "goods-receipt-note",
+    "digest": "sha256:68fd4ef90ac93da7ef42fb2c6d80d7ade6a9861d4edb78b2ee2de1df29fbde0b",
+    "location": "riveros://voi-pilot/evidence/001",
+    "media_type": "application/json"
+  }],
+  "relationships": [],
+  "payload": {
+    "sku_count": 12,
+    "unit_count": 571,
+    "source_node": "urn:vsr:node:factory-001",
+    "destination_node": "urn:vsr:node:voi-pilot-bangalore-001",
+    "document_reference": "GRN-PILOT-0001"
+  },
+  "proof": [{
+    "type": "MockProof",
+    "verification_method": "did:example:voi-pilot-operator#test-key-1",
+    "created": "2026-07-21T10:30:00+05:30",
+    "payload_digest": "sha256:4e24127d1ec2e68283fc58306bbbfaf0a5ac618da87f26fa57c39c1298396b39",
+    "proof_value": "mock:001:57c39c1298396b39"
+  }]
+}

--- a/qel-spec/examples/voi/002-inventory-transferred.json
+++ b/qel-spec/examples/voi/002-inventory-transferred.json
@@ -1,0 +1,46 @@
+{
+  "qel_version": "0.1.0",
+  "id": "urn:qel:expression:voi-pilot-002-inventory-transferred",
+  "kind": "action",
+  "type": "org.virtualsilkroad.inventory.inventory-transferred.v1",
+  "status": "attested",
+  "issuer": { "id": "did:example:voi-pilot-operator", "role": "inventory-transfer-authority" },
+  "actor": { "id": "did:example:voi-pilot-operator", "role": "dispatch-operator" },
+  "subject": { "id": "urn:voi:batch:aw26-00421", "type": "product-batch" },
+  "transition": { "from": "warehouse-custody", "to": "retail-cluster-custody" },
+  "place": { "node": "urn:vsr:node:voi-pilot-bangalore-001", "jurisdiction": "IN-KA" },
+  "time": {
+    "occurred_at": "2026-07-21T11:15:00+05:30",
+    "observed_at": "2026-07-21T11:15:00+05:30",
+    "issued_at": "2026-07-21T11:15:00+05:30"
+  },
+  "authority": [{
+    "type": "inventory-transfer-mandate",
+    "reference": "urn:empireos:license:voi-inventory-transfer-v1",
+    "scope": ["transfer-custody", "dispatch-product"]
+  }],
+  "consent": { "status": "not-applicable", "basis": "commercial-and-operational-record" },
+  "evidence": [{
+    "type": "stock-transfer-note",
+    "digest": "sha256:5ed22e1ab25af7ceadf700bb0a988c8ee1c2f38950b510333e8b7e0a7fd27ad6",
+    "location": "riveros://voi-pilot/evidence/002",
+    "media_type": "application/json"
+  }],
+  "relationships": [{
+    "relation": "caused_by",
+    "expression": "urn:qel:expression:voi-pilot-001-product-received"
+  }],
+  "payload": {
+    "unit_count": 120,
+    "source_node": "urn:vsr:node:voi-pilot-bangalore-001",
+    "destination_node": "urn:vsr:node:retail-cluster-001",
+    "document_reference": "STN-PILOT-0001"
+  },
+  "proof": [{
+    "type": "MockProof",
+    "verification_method": "did:example:voi-pilot-operator#test-key-1",
+    "created": "2026-07-21T11:15:00+05:30",
+    "payload_digest": "sha256:ca79fd49dced1a158599b50165081d593248fcb47271275ab1072737aca23285",
+    "proof_value": "mock:002:b1072737aca23285"
+  }]
+}

--- a/qel-spec/examples/voi/003-product-sold.json
+++ b/qel-spec/examples/voi/003-product-sold.json
@@ -1,0 +1,49 @@
+{
+  "qel_version": "0.1.0",
+  "id": "urn:qel:expression:voi-pilot-003-product-sold",
+  "kind": "action",
+  "type": "org.virtualsilkroad.commerce.product-sold.v1",
+  "status": "attested",
+  "issuer": { "id": "did:example:voi-pilot-operator", "role": "retail-sale-authority" },
+  "actor": { "id": "did:example:voi-pilot-operator", "role": "point-of-sale-system" },
+  "beneficiary": { "id": "did:example:voi-jeans-retail-india", "role": "merchant" },
+  "subject": { "id": "urn:voi:item:aw26-00421-00017", "type": "serialized-product" },
+  "transition": { "from": "available-for-sale", "to": "sold" },
+  "place": { "node": "urn:vsr:node:voi-pilot-bangalore-001", "jurisdiction": "IN-KA" },
+  "time": {
+    "occurred_at": "2026-07-21T15:42:00+05:30",
+    "observed_at": "2026-07-21T15:42:00+05:30",
+    "issued_at": "2026-07-21T15:42:00+05:30"
+  },
+  "authority": [{
+    "type": "retail-sale-mandate",
+    "reference": "urn:empireos:license:voi-retail-sale-v1",
+    "scope": ["sell-product", "create-receivable"]
+  }],
+  "consent": { "status": "not-applicable", "basis": "commercial-and-operational-record" },
+  "evidence": [{
+    "type": "retail-receipt",
+    "digest": "sha256:d8c88ac0d4abc674a1c756f259d2746d9e31338f7a5baf9a93c28899b5c4018d",
+    "location": "riveros://voi-pilot/evidence/003",
+    "media_type": "application/json"
+  }],
+  "relationships": [{
+    "relation": "caused_by",
+    "expression": "urn:qel:expression:voi-pilot-002-inventory-transferred"
+  }],
+  "payload": {
+    "sku": "VOI-AW26-JN-017",
+    "quantity": 1,
+    "gross_amount_minor": 249900,
+    "currency": "INR",
+    "settlement_reference": "urn:voi:settlement:pilot-0001",
+    "receipt_reference": "POS-PILOT-0001"
+  },
+  "proof": [{
+    "type": "MockProof",
+    "verification_method": "did:example:voi-pilot-operator#test-key-1",
+    "created": "2026-07-21T15:42:00+05:30",
+    "payload_digest": "sha256:142c0acd5f76beddc821aa495d52b917505afbee2ec633ef639d2b149dcb2903",
+    "proof_value": "mock:003:639d2b149dcb2903"
+  }]
+}

--- a/qel-spec/examples/voi/004-product-returned.json
+++ b/qel-spec/examples/voi/004-product-returned.json
@@ -1,0 +1,48 @@
+{
+  "qel_version": "0.1.0",
+  "id": "urn:qel:expression:voi-pilot-004-product-returned",
+  "kind": "action",
+  "type": "org.virtualsilkroad.commerce.product-returned.v1",
+  "status": "attested",
+  "issuer": { "id": "did:example:voi-pilot-operator", "role": "return-acceptance-authority" },
+  "actor": { "id": "did:example:voi-pilot-operator", "role": "store-return-operator" },
+  "subject": { "id": "urn:voi:item:aw26-00421-00017", "type": "serialized-product" },
+  "transition": { "from": "sold", "to": "return-inspection" },
+  "place": { "node": "urn:vsr:node:voi-pilot-bangalore-001", "jurisdiction": "IN-KA" },
+  "time": {
+    "occurred_at": "2026-07-21T18:10:00+05:30",
+    "observed_at": "2026-07-21T18:10:00+05:30",
+    "issued_at": "2026-07-21T18:10:00+05:30"
+  },
+  "authority": [{
+    "type": "returns-policy-mandate",
+    "reference": "urn:empireos:license:voi-returns-v1",
+    "scope": ["accept-return", "initiate-refund"]
+  }],
+  "consent": { "status": "not-applicable", "basis": "commercial-and-operational-record" },
+  "evidence": [{
+    "type": "return-acceptance-record",
+    "digest": "sha256:62ed1630b72ade0b8ee9dcc2a6e0cc26bed3941e9c80facdadd1f42abd93466c",
+    "location": "riveros://voi-pilot/evidence/004",
+    "media_type": "application/json"
+  }],
+  "relationships": [{
+    "relation": "caused_by",
+    "expression": "urn:qel:expression:voi-pilot-003-product-sold"
+  }],
+  "payload": {
+    "quantity": 1,
+    "reason_code": "size-exchange",
+    "receipt_reference": "POS-PILOT-0001",
+    "return_reference": "RET-PILOT-0001",
+    "refund_amount_minor": 249900,
+    "currency": "INR"
+  },
+  "proof": [{
+    "type": "MockProof",
+    "verification_method": "did:example:voi-pilot-operator#test-key-1",
+    "created": "2026-07-21T18:10:00+05:30",
+    "payload_digest": "sha256:ac0d5774aa8d8f2f69a6e69adc6393ae9b7cd1e7eb87fb9f9c8505eac629ef92",
+    "proof_value": "mock:004:9c8505eac629ef92"
+  }]
+}

--- a/qel-spec/examples/voi/005-payment-settled.json
+++ b/qel-spec/examples/voi/005-payment-settled.json
@@ -1,0 +1,49 @@
+{
+  "qel_version": "0.1.0",
+  "id": "urn:qel:expression:voi-pilot-005-payment-settled",
+  "kind": "attestation",
+  "type": "org.virtualsilkroad.settlement.payment-settled.v1",
+  "status": "attested",
+  "issuer": { "id": "did:example:voi-pilot-operator", "role": "settlement-attestor" },
+  "actor": { "id": "did:example:voi-pilot-operator", "role": "settlement-connector" },
+  "beneficiary": { "id": "did:example:voi-jeans-retail-india", "role": "settlement-account-holder" },
+  "subject": { "id": "urn:voi:settlement:pilot-0001", "type": "merchant-settlement" },
+  "transition": { "from": "pending", "to": "settled" },
+  "place": { "node": "urn:vsr:node:voi-pilot-bangalore-001", "jurisdiction": "IN-KA" },
+  "time": {
+    "occurred_at": "2026-07-22T09:00:00+05:30",
+    "observed_at": "2026-07-22T09:00:00+05:30",
+    "issued_at": "2026-07-22T09:00:00+05:30"
+  },
+  "authority": [{
+    "type": "settlement-connector-mandate",
+    "reference": "urn:empireos:license:silk-payment-connector-v1",
+    "scope": ["settle-payment", "attest-settlement"]
+  }],
+  "consent": { "status": "not-applicable", "basis": "commercial-and-operational-record" },
+  "evidence": [{
+    "type": "settlement-advice",
+    "digest": "sha256:69cf3f75eab5ea1adbf38b5e671efad9e32e937b5e52c7500d46cf058d1a4f79",
+    "location": "riveros://voi-pilot/evidence/005",
+    "media_type": "application/json"
+  }],
+  "relationships": [
+    { "relation": "caused_by", "expression": "urn:qel:expression:voi-pilot-003-product-sold" },
+    { "relation": "caused_by", "expression": "urn:qel:expression:voi-pilot-004-product-returned" }
+  ],
+  "payload": {
+    "gross_amount_minor": 249900,
+    "return_amount_minor": 249900,
+    "net_amount_minor": 0,
+    "currency": "INR",
+    "settlement_account": "urn:account:pseudonymous:voi-pilot",
+    "bank_reference": "BANK-PILOT-0001"
+  },
+  "proof": [{
+    "type": "MockProof",
+    "verification_method": "did:example:voi-pilot-operator#test-key-1",
+    "created": "2026-07-22T09:00:00+05:30",
+    "payload_digest": "sha256:ac5f4398ba2eaaee7911a145b87f0d0e9ce4192044c9d9ff7f03d108d25bbe6b",
+    "proof_value": "mock:005:7f03d108d25bbe6b"
+  }]
+}

--- a/qel-spec/examples/voi/live/product-received-request.template.json
+++ b/qel-spec/examples/voi/live/product-received-request.template.json
@@ -1,0 +1,38 @@
+{
+  "grn": {
+    "id": "REPLACE-WITH-CONTROLLED-GRN-ID",
+    "issued_at": "2026-07-21T10:30:00+05:30",
+    "source_system": "logic-erp",
+    "document_uri": "riveros://pending/replace-with-grn-evidence-id",
+    "document_digest": "sha256:REPLACE_WITH_64_LOWERCASE_HEX_CHARACTERS"
+  },
+  "warehouse": {
+    "node_id": "urn:vsr:node:warehouse-001",
+    "jurisdiction": "IN-KA"
+  },
+  "operator": {
+    "id": "did:digitalme:operator-001",
+    "role": "receiving-operator",
+    "license_reference": "urn:empireos:license:warehouse-receiving-001"
+  },
+  "shipment": {
+    "dispatch_expression": "urn:qel:expression:optional-dispatch-expression",
+    "purchase_order_id": "REPLACE-WITH-PO-ID",
+    "supplier_id": "urn:organization:replace-with-supplier-id"
+  },
+  "product": {
+    "batch_id": "urn:product-batch:voi:replace-with-batch-id",
+    "sku": "REPLACE-WITH-SKU",
+    "style_code": "REPLACE-WITH-STYLE-CODE",
+    "quantity": 1,
+    "unit": "piece"
+  },
+  "occurred_at": "2026-07-21T10:30:00+05:30",
+  "evidence": [
+    {
+      "type": "receiving-scan",
+      "uri": "riveros://pending/replace-with-receiving-scan-id",
+      "digest": "sha256:REPLACE_WITH_64_LOWERCASE_HEX_CHARACTERS"
+    }
+  ]
+}

--- a/qel-spec/tests/invalid/invalid-status.json
+++ b/qel-spec/tests/invalid/invalid-status.json
@@ -1,0 +1,19 @@
+{
+  "qel_version": "0.1.0",
+  "id": "urn:qel:expression:invalid-status",
+  "kind": "observation",
+  "type": "org.virtualsilkroad.inventory.product-received.v1",
+  "status": "final-truth",
+  "issuer": { "id": "did:example:voi-pilot-operator", "role": "warehouse-receiving-authority" },
+  "actor": { "id": "did:example:voi-pilot-operator", "role": "receiving-operator" },
+  "subject": { "id": "urn:voi:batch:aw26-00421", "type": "product-batch" },
+  "transition": { "from": "in-transit", "to": "received" },
+  "place": { "node": "urn:vsr:node:voi-pilot-bangalore-001", "jurisdiction": "IN-KA" },
+  "time": { "occurred_at": "2026-07-21T10:30:00+05:30", "observed_at": "2026-07-21T10:30:00+05:30", "issued_at": "2026-07-21T10:30:00+05:30" },
+  "authority": [{ "type": "warehouse-receiving-mandate", "reference": "urn:empireos:license:voi-warehouse-receiving-v1", "scope": ["receive-product", "record-custody"] }],
+  "consent": { "status": "not-applicable", "basis": "commercial-and-operational-record" },
+  "evidence": [{ "type": "goods-receipt-note", "digest": "sha256:68fd4ef90ac93da7ef42fb2c6d80d7ade6a9861d4edb78b2ee2de1df29fbde0b", "location": "riveros://voi-pilot/evidence/001", "media_type": "application/json" }],
+  "relationships": [],
+  "payload": { "sku_count": 12, "unit_count": 571, "source_node": "urn:vsr:node:factory-001", "destination_node": "urn:vsr:node:voi-pilot-bangalore-001", "document_reference": "GRN-PILOT-0001" },
+  "proof": [{ "type": "MockProof", "verification_method": "did:example:test#key-1", "created": "2026-07-21T10:30:00+05:30", "payload_digest": "sha256:832cc277547028fa0ca5248c1edc0959eb3b82392903705382dd4ec548b32d25", "proof_value": "mock:invalid" }]
+}

--- a/qel-spec/tests/invalid/missing-issuer.json
+++ b/qel-spec/tests/invalid/missing-issuer.json
@@ -1,0 +1,18 @@
+{
+  "qel_version": "0.1.0",
+  "id": "urn:qel:expression:invalid-missing-issuer",
+  "kind": "observation",
+  "type": "org.virtualsilkroad.inventory.product-received.v1",
+  "status": "attested",
+  "actor": { "id": "did:example:voi-pilot-operator", "role": "receiving-operator" },
+  "subject": { "id": "urn:voi:batch:aw26-00421", "type": "product-batch" },
+  "transition": { "from": "in-transit", "to": "received" },
+  "place": { "node": "urn:vsr:node:voi-pilot-bangalore-001", "jurisdiction": "IN-KA" },
+  "time": { "occurred_at": "2026-07-21T10:30:00+05:30", "observed_at": "2026-07-21T10:30:00+05:30", "issued_at": "2026-07-21T10:30:00+05:30" },
+  "authority": [{ "type": "warehouse-receiving-mandate", "reference": "urn:empireos:license:voi-warehouse-receiving-v1", "scope": ["receive-product", "record-custody"] }],
+  "consent": { "status": "not-applicable", "basis": "commercial-and-operational-record" },
+  "evidence": [{ "type": "goods-receipt-note", "digest": "sha256:68fd4ef90ac93da7ef42fb2c6d80d7ade6a9861d4edb78b2ee2de1df29fbde0b", "location": "riveros://voi-pilot/evidence/001", "media_type": "application/json" }],
+  "relationships": [],
+  "payload": { "sku_count": 12, "unit_count": 571, "source_node": "urn:vsr:node:factory-001", "destination_node": "urn:vsr:node:voi-pilot-bangalore-001", "document_reference": "GRN-PILOT-0001" },
+  "proof": [{ "type": "MockProof", "verification_method": "did:example:test#key-1", "created": "2026-07-21T10:30:00+05:30", "payload_digest": "sha256:42e5b2c999345249c01a068ef33abfee9bd27e81ef2804319e28d4e4d34d439a", "proof_value": "mock:invalid" }]
+}

--- a/server/qel/product-received.test.ts
+++ b/server/qel/product-received.test.ts
@@ -1,0 +1,128 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildProductReceivedExpression,
+  getProductReceivedReadiness,
+  productReceivedRequestSchema,
+  requestRiverOsReceipt,
+  sha256Canonical,
+  validateOperationalAuthority,
+  type ProductReceivedConfig,
+  type ProductReceivedRequest,
+} from "./product-received";
+
+const digest = `sha256:${"a".repeat(64)}`;
+
+const request: ProductReceivedRequest = {
+  grn: {
+    id: "GRN-CONTROLLED-001",
+    issued_at: "2026-07-21T10:30:00+05:30",
+    source_system: "logic-erp",
+    document_uri: "riveros://pending/grn-controlled-001",
+    document_digest: digest,
+  },
+  warehouse: {
+    node_id: "urn:vsr:node:warehouse-001",
+    jurisdiction: "IN-KA",
+  },
+  operator: {
+    id: "did:digitalme:operator-001",
+    role: "receiving-operator",
+    license_reference: "urn:empireos:license:warehouse-receiving-001",
+  },
+  shipment: {
+    purchase_order_id: "PO-CONTROLLED-001",
+    supplier_id: "urn:organization:supplier-001",
+  },
+  product: {
+    batch_id: "urn:product-batch:voi:controlled-001",
+    sku: "VOI-CONTROLLED-SKU",
+    style_code: "VOI-CONTROLLED-STYLE",
+    quantity: 10,
+    unit: "piece",
+  },
+  occurred_at: "2026-07-21T10:30:00+05:30",
+  evidence: [
+    {
+      type: "receiving-scan",
+      uri: "riveros://pending/receiving-scan-controlled-001",
+      digest,
+    },
+  ],
+};
+
+function config(overrides: Partial<ProductReceivedConfig> = {}): ProductReceivedConfig {
+  return {
+    enabled: true,
+    ingestApiKey: "controlled-secret",
+    riverOsEndpoint: "https://riveros.example.test/receipts",
+    warehouseNodes: new Set([request.warehouse.node_id]),
+    operatorLicenses: new Map([
+      [request.operator.id, new Set([request.operator.license_reference])],
+    ]),
+    ...overrides,
+  };
+}
+
+test("readiness requires every production gate", () => {
+  const result = getProductReceivedReadiness(
+    config({ enabled: false, riverOsEndpoint: undefined, warehouseNodes: new Set() }),
+  );
+  assert.equal(result.ready, false);
+  assert.ok(result.missing.includes("QEL_PRODUCT_RECEIVED_ENABLED=true"));
+  assert.ok(result.missing.includes("RIVEROS_RECEIPT_ENDPOINT"));
+  assert.ok(result.missing.includes("QEL_WAREHOUSE_NODES"));
+});
+
+test("request schema and operational authority both pass for the controlled fixture", () => {
+  assert.equal(productReceivedRequestSchema.safeParse(request).success, true);
+  assert.deepEqual(validateOperationalAuthority(request, config()), []);
+});
+
+test("an unlicensed operator is rejected even when the request is structurally valid", () => {
+  const errors = validateOperationalAuthority(
+    request,
+    config({ operatorLicenses: new Map() }),
+  );
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /operator and licence/);
+});
+
+test("expression remains an asserted claim and carries the GRN evidence", () => {
+  const expression = buildProductReceivedExpression(request, {
+    expressionId: "urn:qel:expression:test-product-received",
+    issuedAt: "2026-07-21T05:00:05.000Z",
+  });
+  assert.equal(expression.status, "asserted");
+  assert.equal(expression.type, "org.voijeans.inventory.product-received.v1");
+  assert.equal((expression.payload as Record<string, unknown>).grn_id, request.grn.id);
+  assert.equal((expression.evidence as Array<Record<string, unknown>>)[0].digest, digest);
+});
+
+test("RiverOS receipt must bind to the exact expression digest", async () => {
+  const expression = buildProductReceivedExpression(request, {
+    expressionId: "urn:qel:expression:test-riveros-receipt",
+    issuedAt: "2026-07-21T05:00:05.000Z",
+  });
+  const expressionDigest = sha256Canonical(expression);
+
+  const fakeFetch = async () =>
+    new Response(
+      JSON.stringify({
+        receipt_id: "riveros-receipt-001",
+        received_at: "2026-07-21T05:00:06.000Z",
+        evidence_uri: "riveros://receipts/riveros-receipt-001",
+        expression_digest: expressionDigest,
+        status: "accepted",
+      }),
+      { status: 201, headers: { "Content-Type": "application/json" } },
+    );
+
+  const receipt = await requestRiverOsReceipt(
+    expression,
+    "controlled-idempotency-key",
+    config(),
+    fakeFetch as typeof fetch,
+  );
+  assert.equal(receipt.expression_digest, expressionDigest);
+});

--- a/server/qel/product-received.ts
+++ b/server/qel/product-received.ts
@@ -1,0 +1,302 @@
+import { createHash, randomUUID, timingSafeEqual } from "crypto";
+import { z } from "zod";
+
+const digestPattern = /^sha256:[a-f0-9]{64}$/;
+const uriPattern = /^[a-z][a-z0-9+.-]*:\/\//i;
+
+const evidenceSchema = z.object({
+  type: z.string().min(1).max(100),
+  uri: z.string().regex(uriPattern, "evidence URI must include a scheme"),
+  digest: z.string().regex(digestPattern),
+});
+
+export const productReceivedRequestSchema = z.object({
+  grn: z.object({
+    id: z.string().min(1).max(120),
+    issued_at: z.string().datetime({ offset: true }),
+    source_system: z.enum(["logic-erp", "easycom", "manual-controlled"]),
+    document_uri: z.string().regex(uriPattern, "GRN URI must include a scheme"),
+    document_digest: z.string().regex(digestPattern),
+  }),
+  warehouse: z.object({
+    node_id: z.string().min(1).max(200),
+    jurisdiction: z.string().min(2).max(50),
+  }),
+  operator: z.object({
+    id: z.string().min(1).max(200),
+    role: z.string().min(1).max(100),
+    license_reference: z.string().min(1).max(240),
+  }),
+  shipment: z.object({
+    dispatch_expression: z.string().min(1).max(240).optional(),
+    purchase_order_id: z.string().min(1).max(120),
+    supplier_id: z.string().min(1).max(200),
+  }),
+  product: z.object({
+    batch_id: z.string().min(1).max(200),
+    sku: z.string().min(1).max(120),
+    style_code: z.string().min(1).max(120),
+    quantity: z.number().int().positive(),
+    unit: z.literal("piece"),
+  }),
+  occurred_at: z.string().datetime({ offset: true }),
+  evidence: z.array(evidenceSchema).min(1).max(20),
+});
+
+export type ProductReceivedRequest = z.infer<typeof productReceivedRequestSchema>;
+
+export interface ProductReceivedConfig {
+  enabled: boolean;
+  ingestApiKey?: string;
+  riverOsEndpoint?: string;
+  riverOsApiKey?: string;
+  warehouseNodes: Set<string>;
+  operatorLicenses: Map<string, Set<string>>;
+}
+
+export interface ReadinessResult {
+  ready: boolean;
+  enabled: boolean;
+  missing: string[];
+  warehouseNodeCount: number;
+  licensedOperatorCount: number;
+}
+
+export interface RiverOsReceipt {
+  receipt_id: string;
+  received_at: string;
+  evidence_uri: string;
+  expression_digest: string;
+  status: "accepted";
+}
+
+export interface ProductReceivedSubmission {
+  expression: Record<string, unknown>;
+  expressionDigest: string;
+  receipt: RiverOsReceipt;
+  replayed: boolean;
+}
+
+function parseStringSet(value: string | undefined): Set<string> {
+  return new Set(
+    (value ?? "")
+      .split(",")
+      .map((item) => item.trim())
+      .filter(Boolean),
+  );
+}
+
+function parseOperatorLicenses(value: string | undefined): Map<string, Set<string>> {
+  if (!value) return new Map();
+  const parsed = JSON.parse(value) as Record<string, unknown>;
+  const licenses = new Map<string, Set<string>>();
+
+  for (const [operatorId, references] of Object.entries(parsed)) {
+    if (!Array.isArray(references) || references.some((item) => typeof item !== "string")) {
+      throw new Error(`QEL_PRODUCT_RECEIVED_LICENSES[${operatorId}] must be an array of strings`);
+    }
+    licenses.set(operatorId, new Set(references));
+  }
+
+  return licenses;
+}
+
+export function loadProductReceivedConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): ProductReceivedConfig {
+  return {
+    enabled: env.QEL_PRODUCT_RECEIVED_ENABLED === "true",
+    ingestApiKey: env.QEL_INGEST_API_KEY,
+    riverOsEndpoint: env.RIVEROS_RECEIPT_ENDPOINT,
+    riverOsApiKey: env.RIVEROS_API_KEY,
+    warehouseNodes: parseStringSet(env.QEL_WAREHOUSE_NODES),
+    operatorLicenses: parseOperatorLicenses(env.QEL_PRODUCT_RECEIVED_LICENSES),
+  };
+}
+
+export function getProductReceivedReadiness(config: ProductReceivedConfig): ReadinessResult {
+  const missing: string[] = [];
+  if (!config.enabled) missing.push("QEL_PRODUCT_RECEIVED_ENABLED=true");
+  if (!config.ingestApiKey) missing.push("QEL_INGEST_API_KEY");
+  if (!config.riverOsEndpoint) missing.push("RIVEROS_RECEIPT_ENDPOINT");
+  if (config.warehouseNodes.size === 0) missing.push("QEL_WAREHOUSE_NODES");
+  if (config.operatorLicenses.size === 0) missing.push("QEL_PRODUCT_RECEIVED_LICENSES");
+
+  return {
+    ready: missing.length === 0,
+    enabled: config.enabled,
+    missing,
+    warehouseNodeCount: config.warehouseNodes.size,
+    licensedOperatorCount: config.operatorLicenses.size,
+  };
+}
+
+export function constantTimeSecretMatches(provided: string, expected: string): boolean {
+  const providedBytes = Buffer.from(provided);
+  const expectedBytes = Buffer.from(expected);
+  if (providedBytes.length !== expectedBytes.length) return false;
+  return timingSafeEqual(providedBytes, expectedBytes);
+}
+
+export function validateOperationalAuthority(
+  request: ProductReceivedRequest,
+  config: ProductReceivedConfig,
+): string[] {
+  const errors: string[] = [];
+  if (!config.warehouseNodes.has(request.warehouse.node_id)) {
+    errors.push("warehouse node is not enabled for the Product Received pilot");
+  }
+
+  const allowedLicenses = config.operatorLicenses.get(request.operator.id);
+  if (!allowedLicenses?.has(request.operator.license_reference)) {
+    errors.push("operator and licence reference are not enabled for this pilot");
+  }
+
+  return errors;
+}
+
+function canonicalize(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalize).join(",")}]`;
+
+  const record = value as Record<string, unknown>;
+  const entries = Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${canonicalize(record[key])}`);
+  return `{${entries.join(",")}}`;
+}
+
+export function sha256Canonical(value: unknown): string {
+  return `sha256:${createHash("sha256").update(canonicalize(value)).digest("hex")}`;
+}
+
+export function buildProductReceivedExpression(
+  request: ProductReceivedRequest,
+  options: { expressionId?: string; issuedAt?: string } = {},
+): Record<string, unknown> {
+  const issuedAt = options.issuedAt ?? new Date().toISOString();
+  const expressionId = options.expressionId ?? `urn:qel:expression:${randomUUID()}`;
+
+  const expression: Record<string, unknown> = {
+    qel_version: "0.1.0-draft",
+    id: expressionId,
+    kind: "observation",
+    type: "org.voijeans.inventory.product-received.v1",
+    status: "asserted",
+    issuer: {
+      id: request.operator.id,
+      role: request.operator.role,
+    },
+    actor: {
+      id: request.operator.id,
+      role: request.operator.role,
+    },
+    subject: {
+      id: request.product.batch_id,
+      type: "product-batch",
+    },
+    transition: {
+      from: "dispatched",
+      to: "received",
+    },
+    place: {
+      node: request.warehouse.node_id,
+      jurisdiction: request.warehouse.jurisdiction,
+    },
+    time: {
+      occurred_at: request.occurred_at,
+      observed_at: issuedAt,
+      issued_at: issuedAt,
+    },
+    authority: [
+      {
+        type: "warehouse-receiving-mandate",
+        reference: request.operator.license_reference,
+        issuer: "urn:empireos:license-registry",
+      },
+    ],
+    consent: {
+      status: "not-applicable",
+      basis: "commercial-custody-transfer",
+    },
+    evidence: [
+      {
+        type: "goods-receipt-note",
+        uri: request.grn.document_uri,
+        digest: request.grn.document_digest,
+      },
+      ...request.evidence,
+    ],
+    relationships: request.shipment.dispatch_expression
+      ? [
+          {
+            relation: "caused_by",
+            expression: request.shipment.dispatch_expression,
+          },
+        ]
+      : [],
+    payload: {
+      grn_id: request.grn.id,
+      grn_issued_at: request.grn.issued_at,
+      source_system: request.grn.source_system,
+      purchase_order_id: request.shipment.purchase_order_id,
+      supplier_id: request.shipment.supplier_id,
+      sku: request.product.sku,
+      style_code: request.product.style_code,
+      quantity: request.product.quantity,
+      unit: request.product.unit,
+    },
+    proof: [
+      {
+        type: "OperationalIngestAssertion",
+        verification_method: `${request.operator.id}#configured-ingest-authority`,
+        proof_value: "pending-riveros-receipt",
+      },
+    ],
+  };
+
+  const payloadDigest = sha256Canonical(expression.payload);
+  const proof = expression.proof as Array<Record<string, unknown>>;
+  proof[0].payload_digest = payloadDigest;
+  return expression;
+}
+
+export async function requestRiverOsReceipt(
+  expression: Record<string, unknown>,
+  idempotencyKey: string,
+  config: ProductReceivedConfig,
+  fetchImplementation: typeof fetch = fetch,
+): Promise<RiverOsReceipt> {
+  if (!config.riverOsEndpoint) throw new Error("RiverOS receipt endpoint is not configured");
+
+  const expressionDigest = sha256Canonical(expression);
+  const response = await fetchImplementation(config.riverOsEndpoint, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Idempotency-Key": idempotencyKey,
+      ...(config.riverOsApiKey ? { Authorization: `Bearer ${config.riverOsApiKey}` } : {}),
+    },
+    body: JSON.stringify({ expression, expression_digest: expressionDigest }),
+  });
+
+  if (!response.ok) {
+    const detail = (await response.text()).slice(0, 500);
+    throw new Error(`RiverOS receipt request failed (${response.status}): ${detail}`);
+  }
+
+  const receiptSchema = z.object({
+    receipt_id: z.string().min(1),
+    received_at: z.string().datetime({ offset: true }),
+    evidence_uri: z.string().regex(uriPattern),
+    expression_digest: z.string().regex(digestPattern),
+    status: z.literal("accepted"),
+  });
+  const receipt = receiptSchema.parse(await response.json());
+
+  if (receipt.expression_digest !== expressionDigest) {
+    throw new Error("RiverOS receipt digest does not match the submitted expression");
+  }
+
+  return receipt;
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,16 +1,62 @@
 import type { Express } from "express";
 import { createServer, type Server } from "http";
-import { storage } from "./storage";
+import { readFile } from "fs/promises";
+import path from "path";
+
+const VOI_PILOT_FILES = [
+  "001-product-received.json",
+  "002-inventory-transferred.json",
+  "003-product-sold.json",
+  "004-product-returned.json",
+  "005-payment-settled.json",
+] as const;
+
+async function readVoiPilotExpressions() {
+  const directory = path.join(process.cwd(), "qel-spec", "examples", "voi");
+  return Promise.all(
+    VOI_PILOT_FILES.map(async (filename) => {
+      const raw = await readFile(path.join(directory, filename), "utf-8");
+      return JSON.parse(raw);
+    }),
+  );
+}
 
 export async function registerRoutes(
   httpServer: Server,
-  app: Express
+  app: Express,
 ): Promise<Server> {
-  // put application routes here
-  // prefix all routes with /api
+  app.get("/api/qel/status", (_req, res) => {
+    res.json({
+      language: "Quantum Expression Language",
+      specVersion: "0.1.0-draft",
+      semantics: "signed-claim-not-automatic-fact",
+      frozenSnapshot: "archive/qel-console-2026-07-21",
+      pilot: {
+        name: "VOI five-event pilot",
+        eventCount: VOI_PILOT_FILES.length,
+        eventTypes: [
+          "product-received",
+          "inventory-transferred",
+          "product-sold",
+          "product-returned",
+          "payment-settled",
+        ],
+      },
+      validation: {
+        implementation: "qel-core-python",
+        commands: ["validate", "canonicalize", "hash", "verify-digest"],
+      },
+    });
+  });
 
-  // use storage to perform CRUD operations on the storage interface
-  // e.g. storage.insertUser(user) or storage.getUserByUsername(username)
+  app.get("/api/qel/pilot/voi/events", async (_req, res, next) => {
+    try {
+      const expressions = await readVoiPilotExpressions();
+      res.json({ count: expressions.length, expressions });
+    } catch (error) {
+      next(error);
+    }
+  });
 
   return httpServer;
 }

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2,6 +2,17 @@ import type { Express } from "express";
 import { createServer, type Server } from "http";
 import { readFile } from "fs/promises";
 import path from "path";
+import {
+  buildProductReceivedExpression,
+  constantTimeSecretMatches,
+  getProductReceivedReadiness,
+  loadProductReceivedConfig,
+  productReceivedRequestSchema,
+  requestRiverOsReceipt,
+  sha256Canonical,
+  validateOperationalAuthority,
+  type ProductReceivedSubmission,
+} from "./qel/product-received";
 
 const VOI_PILOT_FILES = [
   "001-product-received.json",
@@ -11,6 +22,11 @@ const VOI_PILOT_FILES = [
   "005-payment-settled.json",
 ] as const;
 
+const productReceivedSubmissions = new Map<
+  string,
+  { requestDigest: string; submission: ProductReceivedSubmission }
+>();
+
 async function readVoiPilotExpressions() {
   const directory = path.join(process.cwd(), "qel-spec", "examples", "voi");
   return Promise.all(
@@ -19,6 +35,22 @@ async function readVoiPilotExpressions() {
       return JSON.parse(raw);
     }),
   );
+}
+
+function getProductReceivedStatus() {
+  try {
+    const config = loadProductReceivedConfig();
+    return { ...getProductReceivedReadiness(config), configurationError: null };
+  } catch (error) {
+    return {
+      ready: false,
+      enabled: false,
+      missing: [],
+      warehouseNodeCount: 0,
+      licensedOperatorCount: 0,
+      configurationError: error instanceof Error ? error.message : "Invalid configuration",
+    };
+  }
 }
 
 export async function registerRoutes(
@@ -41,6 +73,11 @@ export async function registerRoutes(
           "product-returned",
           "payment-settled",
         ],
+        liveActivation: {
+          activeEvent: "product-received",
+          otherEventsEnabled: false,
+          productReceived: getProductReceivedStatus(),
+        },
       },
       validation: {
         implementation: "qel-core-python",
@@ -53,6 +90,130 @@ export async function registerRoutes(
     try {
       const expressions = await readVoiPilotExpressions();
       res.json({ count: expressions.length, expressions });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.get("/api/qel/pilot/voi/product-received/status", (_req, res) => {
+    res.json({
+      eventType: "org.voijeans.inventory.product-received.v1",
+      writeEndpoint: "/api/qel/pilot/voi/product-received",
+      validationEndpoint: "/api/qel/pilot/voi/product-received/validate",
+      activation: getProductReceivedStatus(),
+      controls: [
+        "ingest API authentication",
+        "strict request validation",
+        "warehouse-node allowlist",
+        "operator and licence allowlist",
+        "idempotency-key enforcement",
+        "RiverOS receipt digest match",
+      ],
+    });
+  });
+
+  app.post("/api/qel/pilot/voi/product-received/validate", (req, res) => {
+    const parsed = productReceivedRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({
+        valid: false,
+        errors: parsed.error.issues.map((issue) => ({
+          path: issue.path.join("."),
+          message: issue.message,
+        })),
+      });
+    }
+
+    let config;
+    try {
+      config = loadProductReceivedConfig();
+    } catch (error) {
+      return res.status(503).json({
+        valid: false,
+        errors: [{ path: "configuration", message: error instanceof Error ? error.message : "Invalid configuration" }],
+      });
+    }
+
+    const authorityErrors = validateOperationalAuthority(parsed.data, config);
+    return res.status(authorityErrors.length === 0 ? 200 : 403).json({
+      valid: authorityErrors.length === 0,
+      schemaValid: true,
+      operationalAuthorityValid: authorityErrors.length === 0,
+      errors: authorityErrors,
+      requestDigest: sha256Canonical(parsed.data),
+    });
+  });
+
+  app.post("/api/qel/pilot/voi/product-received", async (req, res, next) => {
+    try {
+      const config = loadProductReceivedConfig();
+      const readiness = getProductReceivedReadiness(config);
+      if (!readiness.ready) {
+        return res.status(503).json({
+          accepted: false,
+          reason: "Product Received ingestion is not ready",
+          activation: readiness,
+        });
+      }
+
+      const providedSecret = req.header("X-QEL-Ingest-Key") ?? "";
+      if (!config.ingestApiKey || !constantTimeSecretMatches(providedSecret, config.ingestApiKey)) {
+        return res.status(401).json({ accepted: false, reason: "Invalid ingest credentials" });
+      }
+
+      const idempotencyKey = req.header("Idempotency-Key")?.trim();
+      if (!idempotencyKey || idempotencyKey.length < 8 || idempotencyKey.length > 200) {
+        return res.status(400).json({
+          accepted: false,
+          reason: "Idempotency-Key header must contain 8 to 200 characters",
+        });
+      }
+
+      const parsed = productReceivedRequestSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return res.status(400).json({
+          accepted: false,
+          reason: "Request validation failed",
+          errors: parsed.error.issues.map((issue) => ({
+            path: issue.path.join("."),
+            message: issue.message,
+          })),
+        });
+      }
+
+      const authorityErrors = validateOperationalAuthority(parsed.data, config);
+      if (authorityErrors.length > 0) {
+        return res.status(403).json({
+          accepted: false,
+          reason: "Operational authority validation failed",
+          errors: authorityErrors,
+        });
+      }
+
+      const requestDigest = sha256Canonical(parsed.data);
+      const existing = productReceivedSubmissions.get(idempotencyKey);
+      if (existing) {
+        if (existing.requestDigest !== requestDigest) {
+          return res.status(409).json({
+            accepted: false,
+            reason: "Idempotency key was already used for a different request",
+          });
+        }
+        return res.status(200).json({ accepted: true, ...existing.submission, replayed: true });
+      }
+
+      const expression = buildProductReceivedExpression(parsed.data);
+      const expressionDigest = sha256Canonical(expression);
+      const receipt = await requestRiverOsReceipt(expression, idempotencyKey, config);
+      const submission: ProductReceivedSubmission = {
+        expression,
+        expressionDigest,
+        receipt,
+        replayed: false,
+      };
+
+      productReceivedSubmissions.set(idempotencyKey, { requestDigest, submission });
+      return res.status(201).json({ accepted: true, ...submission });
     } catch (error) {
       next(error);
     }


### PR DESCRIPTION
## What changed

### Repository and language foundation
- Preserves the pre-extraction console at `archive/qel-console-2026-07-21`.
- Replaces the ambiguous root landing text with the canonical Quantum Expression Language definition.
- Adds `qel-spec/` with a draft Charter, governance rules, versioning, claim semantics, canonicalization, JSON Schema, five valid VOI pilot vectors, and two invalid conformance vectors.
- Adds `qel-core/`, a Python reference implementation with `validate`, `canonicalize`, `hash`, and `verify-digest` commands.
- Adds conformance tests covering all five VOI events and the invalid vectors.
- Adds GitHub Actions checks for the Python reference core and TypeScript console.

### Controlled Product Received increment
- Adds a production-shaped admission service for `org.voijeans.inventory.product-received.v1` only.
- Keeps the write endpoint disabled unless every required environment control is present.
- Requires ingest authentication, strict request validation, a warehouse-node allowlist, an operator/licence allowlist, an idempotency key, and a RiverOS receipt whose digest matches the exact submitted expression.
- Adds preflight validation that performs no write and requests no RiverOS receipt.
- Adds five admission-gate tests.
- Adds a controlled request template, non-operational environment example, activation runbook, and acceptance-record template.
- Shows live activation readiness in the QEL console without exposing a write form.

### Endpoints
- `GET /api/qel/status`
- `GET /api/qel/pilot/voi/events`
- `GET /api/qel/pilot/voi/product-received/status`
- `POST /api/qel/pilot/voi/product-received/validate`
- `POST /api/qel/pilot/voi/product-received`

## Semantic correction

A QEL expression is an integrity-protected claim about reality, not automatic proof of factual truth or legal validity. Schema validity, digest integrity, proof verification, authority validity, evidence sufficiency, policy acceptance, and dispute status remain separate checks.

A RiverOS `accepted` receipt confirms receipt and digest binding. It does not by itself establish the physical truth of the GRN or quantity.

## VOI pilot chain

1. Product received — controlled admission path implemented, disabled by default
2. Inventory transferred — fixture only
3. Product sold — fixture only
4. Product returned — fixture only
5. Payment settled — fixture only

The fixtures and tests are pseudonymous. They contain no production credentials, customer data, real GRN, or bank identifiers.

## Validation

CI runs:

- Python installation and `pytest qel-core/tests`
- Product Received admission-gate tests
- TypeScript checking
- production console build

## Activation material

- `.env.qel.example`
- `docs/VOI_PRODUCT_RECEIVED_RUNBOOK.md`
- `docs/PRODUCT_RECEIVED_ACCEPTANCE_RECORD.md`
- `qel-spec/examples/voi/live/product-received-request.template.json`

## Deliberately deferred

- real DigitalMe cryptographic proof verification
- live authority resolution directly against EmpireOS
- live evidence retrieval and independent physical attestation
- durable idempotency outside RiverOS
- Inventory Transferred, sale, return, or settlement write paths
- dispute/correction UI and workflow
- repository split into separately governed GitHub repositories
