### PR TITLE
Add authorized Pinyin rail CLI and signed node registry

### DIFF
--- a/.github/workflows/pinyin-rail-cli.yml
+++ b/.github/workflows/pinyin-rail-cli.yml
@@ -53,10 +53,21 @@ jobs:
             --jieshu 2026-07-21T23:59:59Z \
             > rail-command.json
           jq -e '.compiled.tool == "rail.logs.export"' rail-command.json
+          jq -e '.compiled.execution.authorization_required == true' rail-command.json
 
-      - name: Preserve compiled command
+      - name: Assemble conformance artifact
+        run: |
+          mkdir -p rail-conformance
+          cp rail-command.json rail-conformance/
+          cp rail-cli/commands.v0.1.json rail-conformance/
+          cp rail-mcp/tool-contracts.v0.1.json rail-conformance/
+          cp rail-mcp/authorization-envelope.schema.v0.1.json rail-conformance/
+          cp rail-mcp/node-registry.schema.v0.1.json rail-conformance/
+          sha256sum rail-conformance/* > rail-conformance/SHA256SUMS
+
+      - name: Preserve compiled command and security contracts
         uses: actions/upload-artifact@v4
         with:
-          name: pinyin-rail-command-${{ github.run_id }}
-          path: rail-command.json
+          name: pinyin-rail-conformance-${{ github.run_id }}
+          path: rail-conformance/
           retention-days: 30

--- a/.github/workflows/pinyin-rail-cli.yml
+++ b/.github/workflows/pinyin-rail-cli.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Compile representative export command
         run: |
-          npm run railctl -- \
+          ./node_modules/.bin/tsx rail-cli/railctl.ts \
             daochu jiedian-rizhi \
             --jiedian vsr://mainnet/IN-KA/operational/warehouse/voi/bangalore/warehouse-001 \
             --kaishi 2026-07-21T00:00:00Z \

--- a/.github/workflows/pinyin-rail-cli.yml
+++ b/.github/workflows/pinyin-rail-cli.yml
@@ -1,0 +1,62 @@
+name: Pinyin rail CLI and MCP
+
+on:
+  pull_request:
+    paths:
+      - "rail-cli/**"
+      - "rail-mcp/**"
+      - "rail-tsconfig.json"
+      - "package.json"
+      - ".github/workflows/pinyin-rail-cli.yml"
+      - "docs/PINYIN_RAIL_CLI_MCP_V0_1.md"
+  push:
+    branches:
+      - main
+      - "agent/pinyin-rail-cli-mcp-v0.1"
+    paths:
+      - "rail-cli/**"
+      - "rail-mcp/**"
+      - "rail-tsconfig.json"
+      - "package.json"
+      - ".github/workflows/pinyin-rail-cli.yml"
+      - "docs/PINYIN_RAIL_CLI_MCP_V0_1.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Type-check rail components
+        run: npm run check:rail
+
+      - name: Test Pinyin command compiler and MCP server
+        run: npm run test:rail
+
+      - name: Compile representative export command
+        run: |
+          npm run railctl -- \
+            daochu jiedian-rizhi \
+            --jiedian vsr://mainnet/IN-KA/operational/warehouse/voi/bangalore/warehouse-001 \
+            --kaishi 2026-07-21T00:00:00Z \
+            --jieshu 2026-07-21T23:59:59Z \
+            > rail-command.json
+          jq -e '.compiled.tool == "rail.logs.export"' rail-command.json
+
+      - name: Preserve compiled command
+        uses: actions/upload-artifact@v4
+        with:
+          name: pinyin-rail-command-${{ github.run_id }}
+          path: rail-command.json
+          retention-days: 30

--- a/docs/PINYIN_RAIL_CLI_MCP_V0_1.md
+++ b/docs/PINYIN_RAIL_CLI_MCP_V0_1.md
@@ -1,17 +1,20 @@
-# Pinyin Rail CLI and MCP Server v0.1
+# Pinyin Rail CLI and MCP Server v0.2
 
 Status: **draft / controlled prototype**
 
-This increment provides a Pinyin operator language for rail-node log operations and communications without making Pinyin itself the machine authority.
+This increment provides a Pinyin operator language for rail-node log operations and communications without making Pinyin itself the machine authority. Every MCP tool call now requires a short-lived DigitalMe/Warden authorization envelope bound to a separately signed node registry.
 
 ## Authority boundary
 
-The four layers are deliberately separate:
+The layers are deliberately separate:
 
 1. Chinese script provides the human display term.
 2. Tone-free ASCII Pinyin provides a terminal-safe operator alias.
 3. A versioned registry maps that alias to one stable canonical tool name.
-4. The MCP server validates and executes the canonical tool according to policy.
+4. A DigitalMe actor proof demonstrates control of the requesting identity.
+5. A Warden policy proof grants a bounded capability.
+6. A Warden registry proof binds exact node definitions and permitted tools.
+7. The MCP server validates the canonical tool, both authorization proofs, the registry signature and the requested scope.
 
 A transliteration table may help resolve characters or aliases, but it must never independently decide what a command means.
 
@@ -19,6 +22,7 @@ A transliteration table may help resolve characters or aliases, but it must neve
 
 | Chinese | Pinyin CLI | Canonical MCP tool |
 | --- | --- | --- |
+| 解析节点 | `chaxun jiedian` | `rail.nodes.resolve` |
 | 导出节点日志 | `daochu jiedian-rizhi` | `rail.logs.export` |
 | 导入节点日志 | `daoru jiedian-rizhi` | `rail.logs.import.prepare` |
 | 查询节点日志 | `chaxun jiedian-rizhi` | `rail.logs.query` |
@@ -40,33 +44,103 @@ npx tsx rail-cli/railctl.ts \
   --jieshu 2026-07-21T23:59:59Z
 ```
 
-The resulting canonical tool is `rail.logs.export`.
+The resulting canonical tool is `rail.logs.export`. Compile-only output states that authorization is required, but it never prints the authorization envelope or its signatures.
+
+## Signed authorization envelope
+
+The schema is `rail-mcp/authorization-envelope.schema.v0.1.json`.
+
+Each envelope contains:
+
+- one DigitalMe issuer and subject DID;
+- the MCP audience;
+- issue, not-before and expiry timestamps;
+- a nonce;
+- the SHA-256 digest of the exact signed node registry;
+- exact granted tools and nodes;
+- allowed communication channels and classifications;
+- maximum export duration and query limit;
+- one Ed25519 DigitalMe actor proof;
+- one Ed25519 Warden policy proof.
+
+Both proofs sign the same canonical envelope content with the `proofs` field removed. A transport bearer credential does not replace this operation-level authorization.
+
+## Signed node registry
+
+The schema is `rail-mcp/node-registry.schema.v0.1.json`.
+
+Each node record defines:
+
+- exact VSR or URN node address;
+- DigitalMe operator identity;
+- node status;
+- jurisdiction;
+- permitted canonical tools;
+- authority references;
+- RiverOS or other evidence sink.
+
+The registry contains a digest over canonical registry content excluding `digest` and `proof`, plus a Warden-registry Ed25519 proof over the same content.
+
+The resolver rejects:
+
+- an invalid or expired registry;
+- a digest mismatch;
+- an untrusted registry key;
+- duplicate node identifiers;
+- a node missing from the registry;
+- suspended or revoked nodes;
+- a tool not permitted by the node;
+- an authorization bound to another registry digest.
+
+The current deterministic JSON canonicalizer is an implementation draft. A ratified release must adopt and test a formally specified canonicalization profile such as RFC 8785 or an explicitly governed equivalent.
+
+## Trust-store bootstrap
+
+The server reads public trust anchors from `RAIL_TRUST_STORE_PATH`. The trust store contains public keys only, each bound to exactly one role:
+
+- `digitalme-actor`;
+- `warden-policy`;
+- `warden-registry`.
+
+The signed registry is read from `RAIL_NODE_REGISTRY_PATH`.
+
+```text
+RAIL_TRUST_STORE_PATH=/controlled/config/rail-trust-store.json
+RAIL_NODE_REGISTRY_PATH=/controlled/config/signed-node-registry.json
+```
+
+Private signing keys must remain in DigitalMe secure storage, a secure enclave, HSM or another approved signer. They must not be committed, uploaded as MCP arguments or stored in the communications outbox.
 
 ## Controlled execution
 
-Live MCP execution requires all of the following:
+Remote MCP execution requires all of the following:
 
-- `--execute`
-- exact confirmation using `--confirm <canonical-tool-name>`
-- `RAIL_MCP_URL` or `--mcp-url`
-- `RAIL_MCP_TOKEN` in the environment
+- `--execute`;
+- exact confirmation using `--confirm <canonical-tool-name>`;
+- `RAIL_MCP_URL` or `--mcp-url`;
+- `RAIL_MCP_TOKEN` in the environment;
+- `RAIL_AUTHORIZATION_FILE` or `--authorization-file` / `--shouquan-wenjian`.
 
-Example:
+Example node resolution:
 
 ```bash
 RAIL_MCP_URL=https://rail.example.invalid/mcp \
 RAIL_MCP_TOKEN='provided-by-secret-manager' \
+RAIL_AUTHORIZATION_FILE=/controlled/capabilities/operator-001.json \
 npx tsx rail-cli/railctl.ts \
-  fasong tongxin \
-  --pindao notion,dropbox \
-  --zhuti 'Warehouse export completed' \
-  --xinxi 'The controlled artifact is ready.' \
-  --ziyuan rail://exports/exp-001,rail://receipts/rcpt-001 \
+  chaxun jiedian \
+  --jiedian vsr://mainnet/IN-KA/operational/warehouse/voi/bangalore/warehouse-001 \
   --execute \
-  --confirm comms.message.send
+  --confirm rail.nodes.resolve
 ```
 
-Do not put tokens, passwords, private keys or API keys in command arguments. The CLI reads its MCP token only from the environment.
+The CLI loads the envelope only when executing and places it in MCP `tools/call` metadata under:
+
+```text
+org.believerscommon/authorization
+```
+
+Do not put transport credentials, passwords or private signing material in command arguments. The transport credential is read from the environment and the signed capability is read from a controlled file.
 
 ## MCP server
 
@@ -78,41 +152,60 @@ npx tsx rail-mcp/server.ts
 
 The server implements:
 
-- `initialize`
-- `notifications/initialized`
-- `ping`
-- `tools/list`
-- `tools/call`
+- `initialize`;
+- `notifications/initialized`;
+- `ping`;
+- `tools/list`;
+- `tools/call`.
 
 The tool contracts are defined in `rail-mcp/tool-contracts.v0.1.json`.
 
+Every `tools/call` is denied unless the server can load its trust store and signed registry and verify the authorization metadata. This enforcement remains active even when a caller bypasses `railctl` and communicates with the MCP server directly.
+
 The stdio server writes protocol messages only to stdout. Operational diagnostics go to stderr.
+
+## Authorization decision
+
+A successful tool result includes a sanitized authorization decision containing:
+
+- decision identifier;
+- authorization identifier;
+- issuer and subject DID;
+- canonical tool;
+- node identifier when applicable;
+- signed registry identifier and digest;
+- verification-method identifiers;
+- evaluation timestamp;
+- `authorized` status.
+
+It does not copy the envelope signatures or public-key material into operation or communication records.
 
 ## Current execution boundary
 
-### Node logs
+### Node resolution and logs
 
-The following tools validate arguments and return a stable preview receipt and resource links:
+The following tools perform full identity, policy and registry authorization, then return a stable result without connecting to a live node:
 
-- `rail.logs.export`
-- `rail.logs.import.prepare`
-- `rail.logs.query`
-- `rail.receipts.get`
+- `rail.nodes.resolve`;
+- `rail.logs.export`;
+- `rail.logs.import.prepare`;
+- `rail.logs.query`;
+- `rail.receipts.get`.
 
-They do not connect to a warehouse, RiverOS, Dropbox or another node in v0.1. A valid preview is not proof that a log exists or that an import is admissible.
+`rail.nodes.resolve` returns the exact signed node record. Log operations return preview receipts and resource links. They do not connect to a warehouse, RiverOS, Dropbox or another node in v0.2. A valid authorization and preview are not proof that a log exists or that an import is admissible.
 
 Log imports are always expressed as `prepare` and default to quarantine. There is intentionally no `rail.logs.import.commit` tool in this increment.
 
 ### Communications
 
-`comms.message.send` remains a preview unless:
+`comms.message.send` also requires a valid signed capability granting every requested channel and the message classification. It remains a preview unless:
 
 ```text
 RAIL_MCP_EXECUTION_ENABLED=true
 RAIL_MCP_OUTBOX_DIR=/controlled/path
 ```
 
-When enabled, it writes a deterministic communication record to the controlled local outbox. This is an acceptance-to-outbox receipt, not proof of delivery to Slack, Notion, Dropbox, GitHub or RiverOS.
+When enabled, it writes a deterministic communication record and sanitized authorization decision to the controlled local outbox. This is an acceptance-to-outbox receipt, not proof of delivery to Slack, Notion, Dropbox, GitHub or RiverOS.
 
 Confidential messages are additionally blocked unless:
 
@@ -122,22 +215,24 @@ RAIL_MCP_CONFIDENTIAL_ENABLED=true
 
 External channel adapters remain a later increment. They must consume the controlled outbox rather than receiving unrestricted raw CLI input.
 
-## Example import preparation
+## Denial codes
 
-```bash
-npx tsx rail-cli/railctl.ts \
-  daoru jiedian-rizhi \
-  --jiedian urn:vsr:node:voi-warehouse-001 \
-  --laiyuan ./warehouse-001-logs.zip \
-  --sha256 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-```
+The authorization layer returns explicit denial codes, including:
 
-The compiled request:
+- `authorization-missing`;
+- `authorization-expired`;
+- `registry-binding-mismatch`;
+- `tool-not-granted`;
+- `node-not-granted`;
+- `node-not-registered`;
+- `node-tool-not-permitted`;
+- `node-inactive`;
+- `export-window-exceeds-grant`;
+- `query-limit-exceeds-grant`;
+- `channel-not-granted`;
+- `classification-not-granted`.
 
-- normalizes the digest to `sha256:<hex>`;
-- enforces validation and quarantine;
-- generates a deterministic idempotency key;
-- does not commit evidence.
+A denial is returned as an MCP tool result with `isError: true`, allowing the client session to continue without converting a policy denial into a protocol crash.
 
 ## Tests
 
@@ -146,15 +241,27 @@ npm run test:rail
 npm run check:rail
 ```
 
-The tests cover command translation, digest normalization, list parsing, exact execution confirmation, node-address validation, MCP initialization, tool discovery, preview-only node operations, secret-field rejection and controlled-outbox communications.
+The tests generate Ed25519 key pairs in memory. No test private key is written to the repository. Coverage includes:
+
+- command translation and node resolution;
+- authorization metadata separation;
+- signed registry verification;
+- dual DigitalMe/Warden proof verification;
+- registry-digest substitution denial;
+- authorization expiry;
+- export-window limits;
+- suspended-node denial;
+- missing tool grants;
+- direct MCP calls without authorization;
+- preview-only node operations.
 
 ## Next controlled increments
 
-1. Add DigitalMe actor and Warden authorization claims to every call.
-2. Add a signed node-registry resolver.
-3. Add RiverOS receipt verification and durable idempotency.
-4. Add adapter workers for GitHub, Slack, Notion and Dropbox.
-5. Add `rail.logs.import.validate`, followed later by a separately governed commit action.
-6. Add QEL expressions for export, import preparation and communication delivery receipts.
+1. Add RiverOS receipt verification and durable idempotency.
+2. Add a controlled adapter-worker protocol for GitHub, Slack, Notion and Dropbox.
+3. Add QEL expressions for authorization decisions, export preparation, import preparation and communication delivery receipts.
+4. Add `rail.logs.import.validate`, followed later by a separately governed commit action.
+5. Ratify the canonicalization profile and publish conformance vectors across implementations.
+6. Add trust-key rotation, revocation lists and registry supersession records.
 
 No production node, external channel or evidence system should be activated until the relevant identity, authority, redaction, retention, dispute and receipt controls are independently tested.

--- a/docs/PINYIN_RAIL_CLI_MCP_V0_1.md
+++ b/docs/PINYIN_RAIL_CLI_MCP_V0_1.md
@@ -1,0 +1,160 @@
+# Pinyin Rail CLI and MCP Server v0.1
+
+Status: **draft / controlled prototype**
+
+This increment provides a Pinyin operator language for rail-node log operations and communications without making Pinyin itself the machine authority.
+
+## Authority boundary
+
+The four layers are deliberately separate:
+
+1. Chinese script provides the human display term.
+2. Tone-free ASCII Pinyin provides a terminal-safe operator alias.
+3. A versioned registry maps that alias to one stable canonical tool name.
+4. The MCP server validates and executes the canonical tool according to policy.
+
+A transliteration table may help resolve characters or aliases, but it must never independently decide what a command means.
+
+## Implemented commands
+
+| Chinese | Pinyin CLI | Canonical MCP tool |
+| --- | --- | --- |
+| 导出节点日志 | `daochu jiedian-rizhi` | `rail.logs.export` |
+| 导入节点日志 | `daoru jiedian-rizhi` | `rail.logs.import.prepare` |
+| 查询节点日志 | `chaxun jiedian-rizhi` | `rail.logs.query` |
+| 查询回执 | `chaxun huizhi` | `rail.receipts.get` |
+| 发送通信 | `fasong tongxin` | `comms.message.send` |
+| 查询通信状态 | `chaxun tongxin-zhuangtai` | `comms.message.status` |
+
+The registry is `rail-cli/commands.v0.1.json`. Machine identifiers must remain stable even if a display phrase or alias is improved later.
+
+## Compile-only default
+
+The CLI is non-destructive by default. It compiles a Pinyin command into a JSON-RPC `tools/call` request and prints it.
+
+```bash
+npx tsx rail-cli/railctl.ts \
+  daochu jiedian-rizhi \
+  --jiedian vsr://mainnet/IN-KA/operational/warehouse/voi/bangalore/warehouse-001 \
+  --kaishi 2026-07-21T00:00:00Z \
+  --jieshu 2026-07-21T23:59:59Z
+```
+
+The resulting canonical tool is `rail.logs.export`.
+
+## Controlled execution
+
+Live MCP execution requires all of the following:
+
+- `--execute`
+- exact confirmation using `--confirm <canonical-tool-name>`
+- `RAIL_MCP_URL` or `--mcp-url`
+- `RAIL_MCP_TOKEN` in the environment
+
+Example:
+
+```bash
+RAIL_MCP_URL=https://rail.example.invalid/mcp \
+RAIL_MCP_TOKEN='provided-by-secret-manager' \
+npx tsx rail-cli/railctl.ts \
+  fasong tongxin \
+  --pindao notion,dropbox \
+  --zhuti 'Warehouse export completed' \
+  --xinxi 'The controlled artifact is ready.' \
+  --ziyuan rail://exports/exp-001,rail://receipts/rcpt-001 \
+  --execute \
+  --confirm comms.message.send
+```
+
+Do not put tokens, passwords, private keys or API keys in command arguments. The CLI reads its MCP token only from the environment.
+
+## MCP server
+
+Start the stdio server with:
+
+```bash
+npx tsx rail-mcp/server.ts
+```
+
+The server implements:
+
+- `initialize`
+- `notifications/initialized`
+- `ping`
+- `tools/list`
+- `tools/call`
+
+The tool contracts are defined in `rail-mcp/tool-contracts.v0.1.json`.
+
+The stdio server writes protocol messages only to stdout. Operational diagnostics go to stderr.
+
+## Current execution boundary
+
+### Node logs
+
+The following tools validate arguments and return a stable preview receipt and resource links:
+
+- `rail.logs.export`
+- `rail.logs.import.prepare`
+- `rail.logs.query`
+- `rail.receipts.get`
+
+They do not connect to a warehouse, RiverOS, Dropbox or another node in v0.1. A valid preview is not proof that a log exists or that an import is admissible.
+
+Log imports are always expressed as `prepare` and default to quarantine. There is intentionally no `rail.logs.import.commit` tool in this increment.
+
+### Communications
+
+`comms.message.send` remains a preview unless:
+
+```text
+RAIL_MCP_EXECUTION_ENABLED=true
+RAIL_MCP_OUTBOX_DIR=/controlled/path
+```
+
+When enabled, it writes a deterministic communication record to the controlled local outbox. This is an acceptance-to-outbox receipt, not proof of delivery to Slack, Notion, Dropbox, GitHub or RiverOS.
+
+Confidential messages are additionally blocked unless:
+
+```text
+RAIL_MCP_CONFIDENTIAL_ENABLED=true
+```
+
+External channel adapters remain a later increment. They must consume the controlled outbox rather than receiving unrestricted raw CLI input.
+
+## Example import preparation
+
+```bash
+npx tsx rail-cli/railctl.ts \
+  daoru jiedian-rizhi \
+  --jiedian urn:vsr:node:voi-warehouse-001 \
+  --laiyuan ./warehouse-001-logs.zip \
+  --sha256 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+```
+
+The compiled request:
+
+- normalizes the digest to `sha256:<hex>`;
+- enforces validation and quarantine;
+- generates a deterministic idempotency key;
+- does not commit evidence.
+
+## Tests
+
+```bash
+npm run test:rail
+npm run check:rail
+```
+
+The tests cover command translation, digest normalization, list parsing, exact execution confirmation, node-address validation, MCP initialization, tool discovery, preview-only node operations, secret-field rejection and controlled-outbox communications.
+
+## Next controlled increments
+
+1. Add DigitalMe actor and Warden authorization claims to every call.
+2. Add a signed node-registry resolver.
+3. Add RiverOS receipt verification and durable idempotency.
+4. Add adapter workers for GitHub, Slack, Notion and Dropbox.
+5. Add `rail.logs.import.validate`, followed later by a separately governed commit action.
+6. Add QEL expressions for export, import preparation and communication delivery receipts.
+
+No production node, external channel or evidence system should be activated until the relevant identity, authority, redaction, retention, dispute and receipt controls are independently tested.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
     "build": "tsx script/build.ts",
     "start": "NODE_ENV=production node dist/index.cjs",
     "check": "tsc",
+    "check:rail": "tsc -p rail-tsconfig.json",
+    "test:rail": "tsx --test rail-cli/*.test.ts rail-mcp/*.test.ts",
+    "railctl": "tsx rail-cli/railctl.ts",
+    "rail:mcp": "tsx rail-mcp/server.ts",
     "db:push": "drizzle-kit push"
   },
   "dependencies": {
@@ -58,7 +62,7 @@
     "memorystore": "^1.6.7",
     "next-themes": "^0.4.6",
     "passport": "^0.7.0",
-    "passport-local": "^1.0.0",
+    "passport-local": "^1.0.38",
     "pg": "^8.16.3",
     "react": "^19.2.0",
     "react-day-picker": "^9.11.1",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "memorystore": "^1.6.7",
     "next-themes": "^0.4.6",
     "passport": "^0.7.0",
-    "passport-local": "^1.0.38",
+    "passport-local": "^1.0.0",
     "pg": "^8.16.3",
     "react": "^19.2.0",
     "react-day-picker": "^9.11.1",

--- a/rail-cli/commands.v0.1.json
+++ b/rail-cli/commands.v0.1.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "registry_version": "0.1.0",
+  "status": "draft",
+  "language_policy": {
+    "display_script": "zh-Hans",
+    "operator_alias": "pinyin-ascii-no-tones",
+    "machine_identifiers": "stable-ascii-canonical",
+    "rule": "Pinyin is an operator alias only. Canonical tool names determine machine meaning."
+  },
+  "commands": [
+    {
+      "display": "导出节点日志",
+      "pinyin": ["daochu", "jiedian-rizhi"],
+      "tool": "rail.logs.export",
+      "required": ["node_id", "from", "to"],
+      "defaults": {
+        "format": "qel-ndjson",
+        "redaction_policy": "strict",
+        "sign": true,
+        "archive": true,
+        "receipt_required": true
+      }
+    },
+    {
+      "display": "导入节点日志",
+      "pinyin": ["daoru", "jiedian-rizhi"],
+      "tool": "rail.logs.import.prepare",
+      "required": ["node_id", "source", "expected_digest"],
+      "defaults": {
+        "validate": true,
+        "quarantine": true,
+        "receipt_required": true
+      }
+    },
+    {
+      "display": "查询节点日志",
+      "pinyin": ["chaxun", "jiedian-rizhi"],
+      "tool": "rail.logs.query",
+      "required": ["node_id"],
+      "defaults": {
+        "limit": 100,
+        "redaction_policy": "strict"
+      }
+    },
+    {
+      "display": "查询回执",
+      "pinyin": ["chaxun", "huizhi"],
+      "tool": "rail.receipts.get",
+      "required": ["receipt_id"],
+      "defaults": {}
+    },
+    {
+      "display": "发送通信",
+      "pinyin": ["fasong", "tongxin"],
+      "tool": "comms.message.send",
+      "required": ["channels", "subject", "message"],
+      "defaults": {
+        "classification": "internal-operational",
+        "receipt_required": true
+      }
+    },
+    {
+      "display": "查询通信状态",
+      "pinyin": ["chaxun", "tongxin-zhuangtai"],
+      "tool": "comms.message.status",
+      "required": ["communication_id"],
+      "defaults": {}
+    }
+  ],
+  "options": {
+    "jiedian": "node_id",
+    "kaishi": "from",
+    "jieshu": "to",
+    "geshi": "format",
+    "tuomin": "redaction_policy",
+    "qianming": "sign",
+    "fengcun": "archive",
+    "huizhi": "receipt_required",
+    "laiyuan": "source",
+    "sha256": "expected_digest",
+    "yanzheng": "validate",
+    "geli": "quarantine",
+    "shijian": "time_window",
+    "jibie": "levels",
+    "shuliang": "limit",
+    "pindao": "channels",
+    "zhuti": "subject",
+    "xinxi": "message",
+    "ziyuan": "resource_links",
+    "fenlei": "classification",
+    "bianhao": "receipt_id",
+    "tongxin-bianhao": "communication_id",
+    "dengmi-key": "idempotency_key"
+  },
+  "list_options": ["levels", "channels", "resource_links"],
+  "boolean_options": ["sign", "archive", "receipt_required", "validate", "quarantine"]
+}

--- a/rail-cli/commands.v0.1.json
+++ b/rail-cli/commands.v0.1.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "registry_version": "0.1.0",
+  "registry_version": "0.2.0",
   "status": "draft",
   "language_policy": {
     "display_script": "zh-Hans",
@@ -9,6 +9,13 @@
     "rule": "Pinyin is an operator alias only. Canonical tool names determine machine meaning."
   },
   "commands": [
+    {
+      "display": "解析节点",
+      "pinyin": ["chaxun", "jiedian"],
+      "tool": "rail.nodes.resolve",
+      "required": ["node_id"],
+      "defaults": {}
+    },
     {
       "display": "导出节点日志",
       "pinyin": ["daochu", "jiedian-rizhi"],

--- a/rail-cli/railctl.authorization.test.ts
+++ b/rail-cli/railctl.authorization.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildToolCall, compileRailCommand } from "./railctl";
+
+const NODE_ID = "vsr://mainnet/IN-KA/operational/warehouse/voi/bangalore/warehouse-001";
+
+test("compiles Pinyin node resolution to the canonical resolver", async () => {
+  const { compiled } = await compileRailCommand([
+    "chaxun",
+    "jiedian",
+    "--jiedian",
+    NODE_ID,
+  ]);
+  assert.equal(compiled.tool, "rail.nodes.resolve");
+  assert.equal(compiled.arguments.node_id, NODE_ID);
+  assert.equal(compiled.execution.authorization_required, true);
+});
+
+test("places a signed capability in MCP metadata without changing tool arguments", async () => {
+  const { compiled } = await compileRailCommand([
+    "chaxun",
+    "jiedian",
+    "--jiedian",
+    NODE_ID,
+  ]);
+  const envelope = {
+    schema: "org.believerscommon.rail.authorization.v1",
+    authorization_id: "auth-example-001",
+  };
+  const request = buildToolCall(compiled, 9, envelope);
+  const params = request.params as Record<string, unknown>;
+  assert.deepEqual(params.arguments, compiled.arguments);
+  assert.deepEqual(params._meta, {
+    "org.believerscommon/authorization": envelope,
+  });
+});
+
+test("accepts the Pinyin authorization-file control without exposing file contents", async () => {
+  const { controls } = await compileRailCommand([
+    "chaxun",
+    "jiedian",
+    "--jiedian",
+    NODE_ID,
+    "--shouquan-wenjian",
+    "/secure/authorization.json",
+  ]);
+  assert.equal(controls.authorizationFile, "/secure/authorization.json");
+});

--- a/rail-cli/railctl.test.ts
+++ b/rail-cli/railctl.test.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildToolCall, compileRailCommand } from "./railctl";
+
+const NODE_ID = "vsr://mainnet/IN-KA/operational/warehouse/voi/bangalore/warehouse-001";
+
+test("compiles Pinyin node-log export into a canonical MCP tool call", async () => {
+  const { compiled, controls } = await compileRailCommand([
+    "daochu",
+    "jiedian-rizhi",
+    "--jiedian",
+    NODE_ID,
+    "--kaishi",
+    "2026-07-21T00:00:00Z",
+    "--jieshu",
+    "2026-07-21T23:59:59Z",
+  ]);
+
+  assert.equal(controls.execute, false);
+  assert.equal(compiled.tool, "rail.logs.export");
+  assert.equal(compiled.arguments.format, "qel-ndjson");
+  assert.equal(compiled.arguments.redaction_policy, "strict");
+  assert.match(String(compiled.arguments.idempotency_key), /^rail-[a-f0-9]{40}$/);
+
+  assert.deepEqual(buildToolCall(compiled), {
+    jsonrpc: "2.0",
+    id: 2,
+    method: "tools/call",
+    params: {
+      name: "rail.logs.export",
+      arguments: compiled.arguments,
+    },
+  });
+});
+
+test("normalizes a controlled import digest and enforces quarantine", async () => {
+  const digest = "A".repeat(64);
+  const { compiled } = await compileRailCommand([
+    "daoru",
+    "jiedian-rizhi",
+    "--jiedian",
+    NODE_ID,
+    "--laiyuan",
+    "./warehouse-001.zip",
+    "--sha256",
+    digest,
+  ]);
+
+  assert.equal(compiled.tool, "rail.logs.import.prepare");
+  assert.equal(compiled.arguments.expected_digest, `sha256:${digest.toLowerCase()}`);
+  assert.equal(compiled.arguments.quarantine, true);
+  assert.equal(compiled.arguments.validate, true);
+});
+
+test("compiles communications channels and resource links as lists", async () => {
+  const { compiled } = await compileRailCommand([
+    "fasong",
+    "tongxin",
+    "--pindao",
+    "slack,notion,dropbox",
+    "--zhuti",
+    "Node export completed",
+    "--xinxi",
+    "The controlled export is ready.",
+    "--ziyuan",
+    "rail://exports/exp-001,rail://receipts/rcpt-001",
+  ]);
+
+  assert.equal(compiled.tool, "comms.message.send");
+  assert.deepEqual(compiled.arguments.channels, ["slack", "notion", "dropbox"]);
+  assert.deepEqual(compiled.arguments.resource_links, [
+    "rail://exports/exp-001",
+    "rail://receipts/rcpt-001",
+  ]);
+});
+
+test("refuses execution without exact canonical confirmation", async () => {
+  await assert.rejects(
+    compileRailCommand([
+      "chaxun",
+      "huizhi",
+      "--bianhao",
+      "rcpt_001",
+      "--execute",
+      "--confirm",
+      "rail.logs.export",
+    ]),
+    /Execution requires --confirm rail\.receipts\.get/,
+  );
+});
+
+test("rejects unregistered node addressing", async () => {
+  await assert.rejects(
+    compileRailCommand([
+      "chaxun",
+      "jiedian-rizhi",
+      "--jiedian",
+      "warehouse-001",
+    ]),
+    /node_id must use vsr:\/\//,
+  );
+});

--- a/rail-cli/railctl.ts
+++ b/rail-cli/railctl.ts
@@ -31,6 +31,7 @@ export type CompiledRailCommand = {
   execution: {
     mode: "compile-only" | "execute";
     confirmation_required: boolean;
+    authorization_required: true;
   };
 };
 
@@ -38,10 +39,12 @@ export type CliControls = {
   execute: boolean;
   confirm?: string;
   mcpUrl?: string;
+  authorizationFile?: string;
 };
 
 const REGISTRY_URL = new URL("./commands.v0.1.json", import.meta.url);
 const MCP_PROTOCOL_VERSION = "2025-06-18";
+const AUTHORIZATION_META_KEY = "org.believerscommon/authorization";
 
 export async function loadRegistry(): Promise<CommandRegistry> {
   const content = await readFile(REGISTRY_URL, "utf8");
@@ -91,6 +94,12 @@ function validateNodeId(value: unknown): void {
   }
 }
 
+function requireControlValue(argv: string[], index: number, name: string): string {
+  const value = argv[index + 1];
+  if (!value || value.startsWith("--")) throw new Error(`${name} requires a value`);
+  return value;
+}
+
 function takeGlobalControls(argv: string[]): { commandArgv: string[]; controls: CliControls } {
   const controls: CliControls = { execute: false };
   const commandArgv: string[] = [];
@@ -102,12 +111,17 @@ function takeGlobalControls(argv: string[]): { commandArgv: string[]; controls: 
       continue;
     }
     if (token === "--confirm") {
-      controls.confirm = argv[index + 1];
+      controls.confirm = requireControlValue(argv, index, token);
       index += 1;
       continue;
     }
     if (token === "--mcp-url") {
-      controls.mcpUrl = argv[index + 1];
+      controls.mcpUrl = requireControlValue(argv, index, token);
+      index += 1;
+      continue;
+    }
+    if (token === "--authorization-file" || token === "--shouquan-wenjian") {
+      controls.authorizationFile = requireControlValue(argv, index, token);
       index += 1;
       continue;
     }
@@ -208,13 +222,14 @@ export async function compileRailCommand(argv: string[]): Promise<{
       execution: {
         mode: controls.execute ? "execute" : "compile-only",
         confirmation_required: true,
+        authorization_required: true,
       },
     },
     controls,
   };
 }
 
-export function buildToolCall(compiled: CompiledRailCommand, id = 2): JsonObject {
+export function buildToolCall(compiled: CompiledRailCommand, id = 2, authorization?: JsonObject): JsonObject {
   return {
     jsonrpc: "2.0",
     id,
@@ -222,6 +237,7 @@ export function buildToolCall(compiled: CompiledRailCommand, id = 2): JsonObject
     params: {
       name: compiled.tool,
       arguments: compiled.arguments,
+      ...(authorization ? { _meta: { [AUTHORIZATION_META_KEY]: authorization } } : {}),
     },
   };
 }
@@ -266,14 +282,27 @@ async function postMcp(
   return { status: response.status, sessionId: returnedSessionId, payload };
 }
 
+async function loadAuthorizationEnvelope(path: string): Promise<JsonObject> {
+  const parsed = JSON.parse(await readFile(path, "utf8"));
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Authorization file must contain one JSON object");
+  }
+  return parsed as JsonObject;
+}
+
 export async function executeCompiledCommand(
   compiled: CompiledRailCommand,
   controls: CliControls,
 ): Promise<unknown> {
   const url = controls.mcpUrl ?? process.env.RAIL_MCP_URL;
   const token = process.env.RAIL_MCP_TOKEN;
+  const authorizationFile = controls.authorizationFile ?? process.env.RAIL_AUTHORIZATION_FILE;
   if (!url) throw new Error("Execution requires RAIL_MCP_URL or --mcp-url");
   if (!token) throw new Error("Execution requires RAIL_MCP_TOKEN in the environment");
+  if (!authorizationFile) {
+    throw new Error("Execution requires RAIL_AUTHORIZATION_FILE or --authorization-file/--shouquan-wenjian");
+  }
+  const authorization = await loadAuthorizationEnvelope(authorizationFile);
 
   const initialize = await postMcp(
     url,
@@ -284,7 +313,7 @@ export async function executeCompiledCommand(
       params: {
         protocolVersion: MCP_PROTOCOL_VERSION,
         capabilities: {},
-        clientInfo: { name: "railctl", version: "0.1.0" },
+        clientInfo: { name: "railctl", version: "0.2.0" },
       },
     },
     token,
@@ -297,7 +326,7 @@ export async function executeCompiledCommand(
     initialize.sessionId,
   );
 
-  const result = await postMcp(url, buildToolCall(compiled), token, initialize.sessionId);
+  const result = await postMcp(url, buildToolCall(compiled, 2, authorization), token, initialize.sessionId);
   return result.payload;
 }
 
@@ -305,7 +334,15 @@ export async function runCli(argv = process.argv.slice(2)): Promise<number> {
   try {
     const { compiled, controls } = await compileRailCommand(argv);
     if (!controls.execute) {
-      process.stdout.write(`${JSON.stringify({ compiled, request: buildToolCall(compiled) }, null, 2)}\n`);
+      process.stdout.write(`${JSON.stringify({
+        compiled,
+        request: buildToolCall(compiled),
+        authorization: {
+          required_for_execution: true,
+          supplied_to_compile_output: false,
+          source: controls.authorizationFile ?? process.env.RAIL_AUTHORIZATION_FILE ?? null,
+        },
+      }, null, 2)}\n`);
       return 0;
     }
 

--- a/rail-cli/railctl.ts
+++ b/rail-cli/railctl.ts
@@ -1,0 +1,323 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+type JsonObject = Record<string, unknown>;
+
+type CommandDefinition = {
+  display: string;
+  pinyin: [string, string];
+  tool: string;
+  required: string[];
+  defaults: JsonObject;
+};
+
+type CommandRegistry = {
+  registry_version: string;
+  commands: CommandDefinition[];
+  options: Record<string, string>;
+  list_options: string[];
+  boolean_options: string[];
+};
+
+export type CompiledRailCommand = {
+  registry_version: string;
+  display: string;
+  pinyin: string;
+  tool: string;
+  arguments: JsonObject;
+  execution: {
+    mode: "compile-only" | "execute";
+    confirmation_required: boolean;
+  };
+};
+
+export type CliControls = {
+  execute: boolean;
+  confirm?: string;
+  mcpUrl?: string;
+};
+
+const REGISTRY_URL = new URL("./commands.v0.1.json", import.meta.url);
+const MCP_PROTOCOL_VERSION = "2025-06-18";
+
+export async function loadRegistry(): Promise<CommandRegistry> {
+  const content = await readFile(REGISTRY_URL, "utf8");
+  return JSON.parse(content) as CommandRegistry;
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableJson).join(",")}]`;
+  }
+  if (value !== null && typeof value === "object") {
+    const object = value as JsonObject;
+    return `{${Object.keys(object)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableJson(object[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function deterministicIdempotencyKey(tool: string, args: JsonObject): string {
+  const digest = createHash("sha256")
+    .update(stableJson({ tool, arguments: args }))
+    .digest("hex");
+  return `rail-${digest.slice(0, 40)}`;
+}
+
+function parseBoolean(raw: string | boolean): boolean {
+  if (typeof raw === "boolean") return raw;
+  if (["true", "1", "yes", "shi"].includes(raw.toLowerCase())) return true;
+  if (["false", "0", "no", "fou"].includes(raw.toLowerCase())) return false;
+  throw new Error(`Invalid boolean value: ${raw}`);
+}
+
+function normalizeDigest(value: unknown): string {
+  if (typeof value !== "string") throw new Error("expected_digest must be a string");
+  const digest = value.toLowerCase().replace(/^sha256:/, "");
+  if (!/^[a-f0-9]{64}$/.test(digest)) {
+    throw new Error("expected_digest must be a SHA-256 digest");
+  }
+  return `sha256:${digest}`;
+}
+
+function validateNodeId(value: unknown): void {
+  if (typeof value !== "string" || !/^(vsr:\/\/|urn:vsr:node:)/.test(value)) {
+    throw new Error("node_id must use vsr:// or urn:vsr:node: addressing");
+  }
+}
+
+function takeGlobalControls(argv: string[]): { commandArgv: string[]; controls: CliControls } {
+  const controls: CliControls = { execute: false };
+  const commandArgv: string[] = [];
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--execute") {
+      controls.execute = true;
+      continue;
+    }
+    if (token === "--confirm") {
+      controls.confirm = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (token === "--mcp-url") {
+      controls.mcpUrl = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    commandArgv.push(token);
+  }
+
+  return { commandArgv, controls };
+}
+
+export async function compileRailCommand(argv: string[]): Promise<{
+  compiled: CompiledRailCommand;
+  controls: CliControls;
+}> {
+  const registry = await loadRegistry();
+  const { commandArgv, controls } = takeGlobalControls(argv);
+  const [verb, object, ...optionTokens] = commandArgv;
+
+  if (!verb || !object) {
+    throw new Error("Usage: railctl <pinyin-verb> <pinyin-object> [options]");
+  }
+
+  const definition = registry.commands.find(
+    (candidate) => candidate.pinyin[0] === verb && candidate.pinyin[1] === object,
+  );
+  if (!definition) {
+    throw new Error(`Unknown Pinyin rail command: ${verb} ${object}`);
+  }
+
+  const args: JsonObject = { ...definition.defaults };
+  for (let index = 0; index < optionTokens.length; index += 1) {
+    const token = optionTokens[index];
+    if (!token.startsWith("--")) {
+      throw new Error(`Unexpected positional argument: ${token}`);
+    }
+
+    const pinyinOption = token.slice(2);
+    const canonicalOption = registry.options[pinyinOption];
+    if (!canonicalOption) throw new Error(`Unknown option: ${token}`);
+
+    if (registry.boolean_options.includes(canonicalOption)) {
+      const possibleValue = optionTokens[index + 1];
+      if (possibleValue && !possibleValue.startsWith("--")) {
+        args[canonicalOption] = parseBoolean(possibleValue);
+        index += 1;
+      } else {
+        args[canonicalOption] = true;
+      }
+      continue;
+    }
+
+    const value = optionTokens[index + 1];
+    if (!value || value.startsWith("--")) {
+      throw new Error(`Option ${token} requires a value`);
+    }
+    index += 1;
+
+    if (registry.list_options.includes(canonicalOption)) {
+      args[canonicalOption] = value.split(",").map((item) => item.trim()).filter(Boolean);
+    } else if (canonicalOption === "limit") {
+      const limit = Number.parseInt(value, 10);
+      if (!Number.isInteger(limit) || limit < 1 || limit > 10_000) {
+        throw new Error("limit must be an integer from 1 to 10000");
+      }
+      args[canonicalOption] = limit;
+    } else {
+      args[canonicalOption] = value;
+    }
+  }
+
+  for (const required of definition.required) {
+    const value = args[required];
+    if (value === undefined || value === null || value === "" || (Array.isArray(value) && value.length === 0)) {
+      throw new Error(`Missing required option for ${definition.tool}: ${required}`);
+    }
+  }
+
+  if ("node_id" in args) validateNodeId(args.node_id);
+  if ("expected_digest" in args) args.expected_digest = normalizeDigest(args.expected_digest);
+
+  if (
+    ["rail.logs.export", "rail.logs.import.prepare", "comms.message.send"].includes(definition.tool) &&
+    !("idempotency_key" in args)
+  ) {
+    args.idempotency_key = deterministicIdempotencyKey(definition.tool, args);
+  }
+
+  if (controls.execute && controls.confirm !== definition.tool) {
+    throw new Error(`Execution requires --confirm ${definition.tool}`);
+  }
+
+  return {
+    compiled: {
+      registry_version: registry.registry_version,
+      display: definition.display,
+      pinyin: definition.pinyin.join(" "),
+      tool: definition.tool,
+      arguments: args,
+      execution: {
+        mode: controls.execute ? "execute" : "compile-only",
+        confirmation_required: true,
+      },
+    },
+    controls,
+  };
+}
+
+export function buildToolCall(compiled: CompiledRailCommand, id = 2): JsonObject {
+  return {
+    jsonrpc: "2.0",
+    id,
+    method: "tools/call",
+    params: {
+      name: compiled.tool,
+      arguments: compiled.arguments,
+    },
+  };
+}
+
+function extractSseJson(text: string): unknown {
+  const dataLines = text
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => line.slice(5).trim());
+  if (dataLines.length === 0) throw new Error("MCP server returned an empty SSE response");
+  return JSON.parse(dataLines.at(-1) as string);
+}
+
+async function postMcp(
+  url: string,
+  body: JsonObject,
+  token: string,
+  sessionId?: string,
+): Promise<{ payload?: unknown; sessionId?: string; status: number }> {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      Accept: "application/json, text/event-stream",
+      "Content-Type": "application/json",
+      "MCP-Protocol-Version": MCP_PROTOCOL_VERSION,
+      Authorization: `Bearer ${token}`,
+      ...(sessionId ? { "MCP-Session-Id": sessionId } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok && response.status !== 202) {
+    throw new Error(`MCP request failed (${response.status}): ${(await response.text()).slice(0, 500)}`);
+  }
+
+  const returnedSessionId = response.headers.get("MCP-Session-Id") ?? sessionId;
+  if (response.status === 202) return { status: response.status, sessionId: returnedSessionId };
+
+  const text = await response.text();
+  const contentType = response.headers.get("content-type") ?? "";
+  const payload = contentType.includes("text/event-stream") ? extractSseJson(text) : JSON.parse(text);
+  return { status: response.status, sessionId: returnedSessionId, payload };
+}
+
+export async function executeCompiledCommand(
+  compiled: CompiledRailCommand,
+  controls: CliControls,
+): Promise<unknown> {
+  const url = controls.mcpUrl ?? process.env.RAIL_MCP_URL;
+  const token = process.env.RAIL_MCP_TOKEN;
+  if (!url) throw new Error("Execution requires RAIL_MCP_URL or --mcp-url");
+  if (!token) throw new Error("Execution requires RAIL_MCP_TOKEN in the environment");
+
+  const initialize = await postMcp(
+    url,
+    {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: { name: "railctl", version: "0.1.0" },
+      },
+    },
+    token,
+  );
+
+  await postMcp(
+    url,
+    { jsonrpc: "2.0", method: "notifications/initialized", params: {} },
+    token,
+    initialize.sessionId,
+  );
+
+  const result = await postMcp(url, buildToolCall(compiled), token, initialize.sessionId);
+  return result.payload;
+}
+
+export async function runCli(argv = process.argv.slice(2)): Promise<number> {
+  try {
+    const { compiled, controls } = await compileRailCommand(argv);
+    if (!controls.execute) {
+      process.stdout.write(`${JSON.stringify({ compiled, request: buildToolCall(compiled) }, null, 2)}\n`);
+      return 0;
+    }
+
+    const response = await executeCompiledCommand(compiled, controls);
+    process.stdout.write(`${JSON.stringify(response, null, 2)}\n`);
+    return 0;
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    return 1;
+  }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === fileURLToPath(new URL(`file://${process.argv[1]}`))) {
+  process.exitCode = await runCli();
+}

--- a/rail-mcp/authorization-envelope.schema.v0.1.json
+++ b/rail-mcp/authorization-envelope.schema.v0.1.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://believerscommon.example/schemas/rail/authorization-envelope/v0.1",
+  "title": "DigitalMe and Warden Rail Authorization Envelope",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "authorization_id",
+    "issuer_did",
+    "subject_did",
+    "audience",
+    "issued_at",
+    "not_before",
+    "expires_at",
+    "nonce",
+    "registry_digest",
+    "grants",
+    "proofs"
+  ],
+  "properties": {
+    "schema": {"const": "org.believerscommon.rail.authorization.v1"},
+    "authorization_id": {"type": "string", "minLength": 8},
+    "issuer_did": {"type": "string", "pattern": "^did:digitalme:"},
+    "subject_did": {"type": "string", "pattern": "^did:digitalme:"},
+    "audience": {"const": "qel-pinyin-rail-mcp"},
+    "issued_at": {"type": "string", "format": "date-time"},
+    "not_before": {"type": "string", "format": "date-time"},
+    "expires_at": {"type": "string", "format": "date-time"},
+    "nonce": {"type": "string", "minLength": 16},
+    "registry_digest": {"type": "string", "pattern": "^sha256:[a-f0-9]{64}$"},
+    "grants": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "tools",
+        "nodes",
+        "channels",
+        "classifications",
+        "max_export_seconds",
+        "max_query_limit"
+      ],
+      "properties": {
+        "tools": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string"}},
+        "nodes": {"type": "array", "uniqueItems": true, "items": {"type": "string", "pattern": "^(vsr://|urn:vsr:node:)"}},
+        "channels": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {"enum": ["github", "slack", "notion", "dropbox", "riveros"]}
+        },
+        "classifications": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {"enum": ["public", "internal-operational", "confidential"]}
+        },
+        "max_export_seconds": {"type": "integer", "minimum": 1, "maximum": 2678400},
+        "max_query_limit": {"type": "integer", "minimum": 1, "maximum": 10000}
+      }
+    },
+    "proofs": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "items": {"$ref": "#/$defs/proof"}
+    }
+  },
+  "$defs": {
+    "proof": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "role", "verification_method", "created", "signature"],
+      "properties": {
+        "type": {"const": "Ed25519Signature"},
+        "role": {"enum": ["digitalme-actor", "warden-policy"]},
+        "verification_method": {"type": "string", "minLength": 3},
+        "created": {"type": "string", "format": "date-time"},
+        "signature": {"type": "string", "pattern": "^[A-Za-z0-9_-]+$"}
+      }
+    }
+  }
+}

--- a/rail-mcp/authorization.test.ts
+++ b/rail-mcp/authorization.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { authorizeToolCall, authorizationMeta, verifyNodeRegistry } from "./authorization";
+import { createTestSecurityFixture, TEST_NODE_ID } from "./test-security";
+
+const EXPORT_ARGS = {
+  node_id: TEST_NODE_ID,
+  from: "2026-07-21T00:00:00Z",
+  to: "2026-07-21T23:59:59Z",
+  format: "qel-ndjson",
+  redaction_policy: "strict",
+  sign: true,
+  archive: true,
+  receipt_required: true,
+  idempotency_key: "rail-1234567890abcdef",
+};
+
+test("verifies a Warden-signed node registry and resolves exact nodes", () => {
+  const fixture = createTestSecurityFixture();
+  const verified = verifyNodeRegistry(fixture.registry, fixture.trustStore, fixture.context.now);
+  assert.equal(verified.digest, fixture.registry.digest);
+  assert.equal(verified.nodes.get(TEST_NODE_ID)?.operator_did, "did:digitalme:voi-warehouse-001");
+});
+
+test("authorizes an export only after both DigitalMe and Warden proofs verify", () => {
+  const fixture = createTestSecurityFixture();
+  const result = authorizeToolCall(
+    "rail.logs.export",
+    EXPORT_ARGS,
+    authorizationMeta(fixture.envelope),
+    fixture.context,
+  );
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.decision.status, "authorized");
+  assert.equal(result.decision.node_id, TEST_NODE_ID);
+  assert.equal(result.decision.proof_methods.length, 2);
+  assert.equal(result.node?.status, "controlled-pilot");
+});
+
+test("denies an authorization bound to a substituted registry digest", () => {
+  const fixture = createTestSecurityFixture();
+  fixture.envelope.registry_digest = `sha256:${"0".repeat(64)}`;
+  const result = authorizeToolCall(
+    "rail.logs.export",
+    EXPORT_ARGS,
+    authorizationMeta(fixture.envelope),
+    fixture.context,
+  );
+  assert.deepEqual(result, {
+    ok: false,
+    code: "registry-binding-mismatch",
+    message: "Authorization is bound to a different node-registry digest",
+  });
+});
+
+test("denies expired authorizations", () => {
+  const now = new Date("2026-07-21T12:00:00Z");
+  const fixture = createTestSecurityFixture({
+    now,
+    authorizationExpiresAt: new Date(now.getTime() - 1),
+  });
+  const result = authorizeToolCall(
+    "rail.logs.export",
+    EXPORT_ARGS,
+    authorizationMeta(fixture.envelope),
+    fixture.context,
+  );
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(result.code, "authorization-expired");
+});
+
+test("denies export windows larger than the Warden grant", () => {
+  const fixture = createTestSecurityFixture({ maxExportSeconds: 3_600 });
+  const result = authorizeToolCall(
+    "rail.logs.export",
+    EXPORT_ARGS,
+    authorizationMeta(fixture.envelope),
+    fixture.context,
+  );
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(result.code, "export-window-exceeds-grant");
+});
+
+test("denies suspended registry nodes even with valid signatures", () => {
+  const fixture = createTestSecurityFixture({ nodeStatus: "suspended" });
+  const result = authorizeToolCall(
+    "rail.logs.export",
+    EXPORT_ARGS,
+    authorizationMeta(fixture.envelope),
+    fixture.context,
+  );
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(result.code, "node-inactive");
+});
+
+test("denies tools omitted from the signed grant", () => {
+  const fixture = createTestSecurityFixture({ grantedTools: ["rail.nodes.resolve"] });
+  const result = authorizeToolCall(
+    "rail.logs.export",
+    EXPORT_ARGS,
+    authorizationMeta(fixture.envelope),
+    fixture.context,
+  );
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(result.code, "tool-not-granted");
+});

--- a/rail-mcp/authorization.ts
+++ b/rail-mcp/authorization.ts
@@ -1,0 +1,371 @@
+import { createHash, createPublicKey, verify as verifySignature } from "node:crypto";
+import { readFile } from "node:fs/promises";
+
+type JsonObject = Record<string, unknown>;
+
+type ProofRole = "digitalme-actor" | "warden-policy" | "warden-registry";
+
+type DetachedProof = {
+  type: "Ed25519Signature";
+  role: ProofRole;
+  verification_method: string;
+  created: string;
+  signature: string;
+};
+
+export type TrustStore = {
+  schema: "org.believerscommon.rail.trust-store.v1";
+  version: string;
+  keys: Array<{
+    verification_method: string;
+    role: ProofRole;
+    public_key_pem: string;
+    status: "active" | "revoked";
+  }>;
+};
+
+export type AuthorizationEnvelope = {
+  schema: "org.believerscommon.rail.authorization.v1";
+  authorization_id: string;
+  issuer_did: string;
+  subject_did: string;
+  audience: "qel-pinyin-rail-mcp";
+  issued_at: string;
+  not_before: string;
+  expires_at: string;
+  nonce: string;
+  registry_digest: string;
+  grants: {
+    tools: string[];
+    nodes: string[];
+    channels: string[];
+    classifications: string[];
+    max_export_seconds: number;
+    max_query_limit: number;
+  };
+  proofs: DetachedProof[];
+};
+
+export type RailNodeRecord = {
+  node_id: string;
+  operator_did: string;
+  status: "controlled-pilot" | "active" | "suspended" | "revoked";
+  jurisdiction: string;
+  permitted_tools: string[];
+  authority_refs: string[];
+  evidence_sink: string;
+};
+
+export type SignedNodeRegistry = {
+  schema: "org.believerscommon.rail.node-registry.v1";
+  registry_id: string;
+  version: string;
+  issued_at: string;
+  expires_at: string;
+  nodes: RailNodeRecord[];
+  digest: string;
+  proof: DetachedProof;
+};
+
+export type SecurityContext = {
+  trustStore: TrustStore;
+  registry: SignedNodeRegistry;
+  now?: Date;
+};
+
+export type AuthorizationDecision = {
+  decision_id: string;
+  authorization_id: string;
+  subject_did: string;
+  issuer_did: string;
+  tool: string;
+  node_id: string | null;
+  registry_id: string;
+  registry_digest: string;
+  proof_methods: string[];
+  evaluated_at: string;
+  status: "authorized";
+};
+
+export type AuthorizationResult =
+  | { ok: true; decision: AuthorizationDecision; node?: RailNodeRecord }
+  | { ok: false; code: string; message: string };
+
+const AUTHORIZATION_META_KEY = "org.believerscommon/authorization";
+
+export function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (value !== null && typeof value === "object") {
+    const object = value as JsonObject;
+    return `{${Object.keys(object)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(object[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function sha256(value: unknown): string {
+  return `sha256:${createHash("sha256").update(canonicalJson(value)).digest("hex")}`;
+}
+
+function withoutKeys<T extends JsonObject>(value: T, keys: string[]): JsonObject {
+  return Object.fromEntries(Object.entries(value).filter(([key]) => !keys.includes(key)));
+}
+
+function isObject(value: unknown): value is JsonObject {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function parseTimestamp(value: unknown, name: string): Date {
+  if (typeof value !== "string") throw new Error(`${name} must be an ISO date-time string`);
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) throw new Error(`${name} must be a valid ISO date-time string`);
+  return parsed;
+}
+
+function assertStringArray(value: unknown, name: string): asserts value is string[] {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
+    throw new Error(`${name} must be an array of strings`);
+  }
+}
+
+function verifyProof(
+  payload: JsonObject,
+  proof: DetachedProof,
+  role: ProofRole,
+  trustStore: TrustStore,
+  now: Date,
+): string {
+  if (!isObject(proof) || proof.type !== "Ed25519Signature" || proof.role !== role) {
+    throw new Error(`Missing or invalid ${role} proof`);
+  }
+  parseTimestamp(proof.created, `${role}.created`);
+  if (new Date(proof.created).getTime() > now.getTime() + 5 * 60_000) {
+    throw new Error(`${role} proof creation time is in the future`);
+  }
+  const trustKey = trustStore.keys.find(
+    (key) => key.verification_method === proof.verification_method && key.role === role,
+  );
+  if (!trustKey || trustKey.status !== "active") {
+    throw new Error(`No active trust key for ${role}: ${proof.verification_method}`);
+  }
+  if (typeof proof.signature !== "string" || !/^[A-Za-z0-9_-]+$/.test(proof.signature)) {
+    throw new Error(`${role} signature must be base64url`);
+  }
+  const verified = verifySignature(
+    null,
+    Buffer.from(canonicalJson(payload), "utf8"),
+    createPublicKey(trustKey.public_key_pem),
+    Buffer.from(proof.signature, "base64url"),
+  );
+  if (!verified) throw new Error(`${role} signature verification failed`);
+  return proof.verification_method;
+}
+
+export function registrySigningPayload(registry: SignedNodeRegistry): JsonObject {
+  return withoutKeys(registry as unknown as JsonObject, ["digest", "proof"]);
+}
+
+export function authorizationSigningPayload(envelope: AuthorizationEnvelope): JsonObject {
+  return withoutKeys(envelope as unknown as JsonObject, ["proofs"]);
+}
+
+export function calculateRegistryDigest(registry: SignedNodeRegistry): string {
+  return sha256(registrySigningPayload(registry));
+}
+
+function verifyTrustStore(trustStore: TrustStore): void {
+  if (!isObject(trustStore) || trustStore.schema !== "org.believerscommon.rail.trust-store.v1") {
+    throw new Error("Invalid rail trust store schema");
+  }
+  if (!Array.isArray(trustStore.keys) || trustStore.keys.length < 3) {
+    throw new Error("Trust store must contain DigitalMe, Warden policy and Warden registry keys");
+  }
+  const ids = new Set<string>();
+  for (const key of trustStore.keys) {
+    if (!isObject(key) || typeof key.verification_method !== "string" || typeof key.public_key_pem !== "string") {
+      throw new Error("Invalid trust-store key entry");
+    }
+    if (ids.has(key.verification_method)) throw new Error(`Duplicate trust key: ${key.verification_method}`);
+    ids.add(key.verification_method);
+  }
+}
+
+export function verifyNodeRegistry(
+  registry: SignedNodeRegistry,
+  trustStore: TrustStore,
+  now = new Date(),
+): { digest: string; nodes: Map<string, RailNodeRecord>; proofMethod: string } {
+  verifyTrustStore(trustStore);
+  if (!isObject(registry) || registry.schema !== "org.believerscommon.rail.node-registry.v1") {
+    throw new Error("Invalid node-registry schema");
+  }
+  const issuedAt = parseTimestamp(registry.issued_at, "registry.issued_at");
+  const expiresAt = parseTimestamp(registry.expires_at, "registry.expires_at");
+  if (issuedAt.getTime() > now.getTime() + 5 * 60_000) throw new Error("Node registry is not yet valid");
+  if (expiresAt.getTime() <= now.getTime()) throw new Error("Node registry has expired");
+  if (!Array.isArray(registry.nodes)) throw new Error("Node registry nodes must be an array");
+
+  const payload = registrySigningPayload(registry);
+  const digest = sha256(payload);
+  if (registry.digest !== digest) throw new Error("Node-registry digest does not match canonical content");
+  const proofMethod = verifyProof(payload, registry.proof, "warden-registry", trustStore, now);
+
+  const nodes = new Map<string, RailNodeRecord>();
+  for (const node of registry.nodes) {
+    if (!isObject(node) || typeof node.node_id !== "string" || !/^(vsr:\/\/|urn:vsr:node:)/.test(node.node_id)) {
+      throw new Error("Node registry contains an invalid node_id");
+    }
+    if (nodes.has(node.node_id)) throw new Error(`Duplicate node registry entry: ${node.node_id}`);
+    assertStringArray(node.permitted_tools, `${node.node_id}.permitted_tools`);
+    assertStringArray(node.authority_refs, `${node.node_id}.authority_refs`);
+    nodes.set(node.node_id, node as unknown as RailNodeRecord);
+  }
+  return { digest, nodes, proofMethod };
+}
+
+function verifyEnvelopeShape(envelope: AuthorizationEnvelope): void {
+  if (!isObject(envelope) || envelope.schema !== "org.believerscommon.rail.authorization.v1") {
+    throw new Error("Invalid authorization-envelope schema");
+  }
+  if (envelope.audience !== "qel-pinyin-rail-mcp") throw new Error("Authorization audience mismatch");
+  if (typeof envelope.authorization_id !== "string" || envelope.authorization_id.length < 8) {
+    throw new Error("authorization_id is invalid");
+  }
+  if (typeof envelope.issuer_did !== "string" || !envelope.issuer_did.startsWith("did:digitalme:")) {
+    throw new Error("issuer_did must be a DigitalMe DID");
+  }
+  if (typeof envelope.subject_did !== "string" || !envelope.subject_did.startsWith("did:digitalme:")) {
+    throw new Error("subject_did must be a DigitalMe DID");
+  }
+  if (!isObject(envelope.grants)) throw new Error("Authorization grants are required");
+  assertStringArray(envelope.grants.tools, "grants.tools");
+  assertStringArray(envelope.grants.nodes, "grants.nodes");
+  assertStringArray(envelope.grants.channels, "grants.channels");
+  assertStringArray(envelope.grants.classifications, "grants.classifications");
+  if (!Number.isInteger(envelope.grants.max_export_seconds) || envelope.grants.max_export_seconds < 1) {
+    throw new Error("grants.max_export_seconds must be a positive integer");
+  }
+  if (!Number.isInteger(envelope.grants.max_query_limit) || envelope.grants.max_query_limit < 1) {
+    throw new Error("grants.max_query_limit must be a positive integer");
+  }
+  if (!Array.isArray(envelope.proofs)) throw new Error("Authorization proofs are required");
+}
+
+function deny(code: string, message: string): AuthorizationResult {
+  return { ok: false, code, message };
+}
+
+export function authorizeToolCall(
+  tool: string,
+  args: JsonObject,
+  meta: JsonObject | undefined,
+  context: SecurityContext,
+): AuthorizationResult {
+  try {
+    const now = context.now ?? new Date();
+    const verifiedRegistry = verifyNodeRegistry(context.registry, context.trustStore, now);
+    const candidate = meta?.[AUTHORIZATION_META_KEY];
+    if (!isObject(candidate)) return deny("authorization-missing", `Missing ${AUTHORIZATION_META_KEY} metadata`);
+    const envelope = candidate as unknown as AuthorizationEnvelope;
+    verifyEnvelopeShape(envelope);
+
+    const issuedAt = parseTimestamp(envelope.issued_at, "authorization.issued_at");
+    const notBefore = parseTimestamp(envelope.not_before, "authorization.not_before");
+    const expiresAt = parseTimestamp(envelope.expires_at, "authorization.expires_at");
+    if (issuedAt.getTime() > now.getTime() + 5 * 60_000) return deny("authorization-not-yet-issued", "Authorization issue time is in the future");
+    if (notBefore.getTime() > now.getTime()) return deny("authorization-not-yet-valid", "Authorization is not yet valid");
+    if (expiresAt.getTime() <= now.getTime()) return deny("authorization-expired", "Authorization has expired");
+    if (expiresAt.getTime() <= notBefore.getTime()) return deny("authorization-window-invalid", "Authorization validity window is invalid");
+    if (envelope.registry_digest !== verifiedRegistry.digest) {
+      return deny("registry-binding-mismatch", "Authorization is bound to a different node-registry digest");
+    }
+
+    const payload = authorizationSigningPayload(envelope);
+    const actorProof = envelope.proofs.find((proof) => proof.role === "digitalme-actor");
+    const policyProof = envelope.proofs.find((proof) => proof.role === "warden-policy");
+    if (!actorProof || !policyProof) return deny("authorization-proof-missing", "DigitalMe actor and Warden policy proofs are both required");
+    const proofMethods = [
+      verifyProof(payload, actorProof, "digitalme-actor", context.trustStore, now),
+      verifyProof(payload, policyProof, "warden-policy", context.trustStore, now),
+    ];
+
+    if (!envelope.grants.tools.includes(tool)) return deny("tool-not-granted", `Authorization does not grant ${tool}`);
+
+    const nodeId = typeof args.node_id === "string" ? args.node_id : null;
+    let node: RailNodeRecord | undefined;
+    if (nodeId) {
+      if (!envelope.grants.nodes.includes(nodeId)) return deny("node-not-granted", `Authorization does not grant node ${nodeId}`);
+      node = verifiedRegistry.nodes.get(nodeId);
+      if (!node) return deny("node-not-registered", `Node is not present in the signed registry: ${nodeId}`);
+      if (!node.permitted_tools.includes(tool)) return deny("node-tool-not-permitted", `Node ${nodeId} does not permit ${tool}`);
+      if (!["controlled-pilot", "active"].includes(node.status)) return deny("node-inactive", `Node ${nodeId} status is ${node.status}`);
+    }
+
+    if (tool === "rail.logs.export") {
+      const from = parseTimestamp(args.from, "arguments.from");
+      const to = parseTimestamp(args.to, "arguments.to");
+      const seconds = (to.getTime() - from.getTime()) / 1000;
+      if (seconds < 0) return deny("export-window-invalid", "Export end time precedes start time");
+      if (seconds > envelope.grants.max_export_seconds) {
+        return deny("export-window-exceeds-grant", `Export window exceeds ${envelope.grants.max_export_seconds} seconds`);
+      }
+    }
+
+    if (tool === "rail.logs.query") {
+      const limit = typeof args.limit === "number" ? args.limit : 100;
+      if (limit > envelope.grants.max_query_limit) {
+        return deny("query-limit-exceeds-grant", `Query limit exceeds ${envelope.grants.max_query_limit}`);
+      }
+    }
+
+    if (tool === "comms.message.send") {
+      const channels = Array.isArray(args.channels) ? args.channels.filter((item): item is string => typeof item === "string") : [];
+      const unauthorizedChannel = channels.find((channel) => !envelope.grants.channels.includes(channel));
+      if (unauthorizedChannel) return deny("channel-not-granted", `Authorization does not grant channel ${unauthorizedChannel}`);
+      const classification = typeof args.classification === "string" ? args.classification : "internal-operational";
+      if (!envelope.grants.classifications.includes(classification)) {
+        return deny("classification-not-granted", `Authorization does not grant classification ${classification}`);
+      }
+    }
+
+    const evaluatedAt = now.toISOString();
+    const decision: AuthorizationDecision = {
+      decision_id: sha256({ authorization_id: envelope.authorization_id, tool, args, registry_digest: verifiedRegistry.digest, evaluated_at: evaluatedAt }).slice(7, 39),
+      authorization_id: envelope.authorization_id,
+      subject_did: envelope.subject_did,
+      issuer_did: envelope.issuer_did,
+      tool,
+      node_id: nodeId,
+      registry_id: context.registry.registry_id,
+      registry_digest: verifiedRegistry.digest,
+      proof_methods: proofMethods,
+      evaluated_at: evaluatedAt,
+      status: "authorized",
+    };
+    return { ok: true, decision, ...(node ? { node } : {}) };
+  } catch (error) {
+    return deny("authorization-invalid", error instanceof Error ? error.message : String(error));
+  }
+}
+
+export function authorizationMeta(envelope: AuthorizationEnvelope): JsonObject {
+  return { [AUTHORIZATION_META_KEY]: envelope };
+}
+
+export async function loadSecurityContextFromEnvironment(): Promise<SecurityContext> {
+  const trustStorePath = process.env.RAIL_TRUST_STORE_PATH;
+  const registryPath = process.env.RAIL_NODE_REGISTRY_PATH;
+  if (!trustStorePath || !registryPath) {
+    throw new Error("RAIL_TRUST_STORE_PATH and RAIL_NODE_REGISTRY_PATH are required for tools/call");
+  }
+  const [trustStoreContent, registryContent] = await Promise.all([
+    readFile(trustStorePath, "utf8"),
+    readFile(registryPath, "utf8"),
+  ]);
+  return {
+    trustStore: JSON.parse(trustStoreContent) as TrustStore,
+    registry: JSON.parse(registryContent) as SignedNodeRegistry,
+  };
+}

--- a/rail-mcp/node-registry.schema.v0.1.json
+++ b/rail-mcp/node-registry.schema.v0.1.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://believerscommon.example/schemas/rail/node-registry/v0.1",
+  "title": "Signed Rail Node Registry",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "registry_id",
+    "version",
+    "issued_at",
+    "expires_at",
+    "nodes",
+    "digest",
+    "proof"
+  ],
+  "properties": {
+    "schema": {"const": "org.believerscommon.rail.node-registry.v1"},
+    "registry_id": {"type": "string", "minLength": 8},
+    "version": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"},
+    "issued_at": {"type": "string", "format": "date-time"},
+    "expires_at": {"type": "string", "format": "date-time"},
+    "nodes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "node_id",
+          "operator_did",
+          "status",
+          "jurisdiction",
+          "permitted_tools",
+          "authority_refs",
+          "evidence_sink"
+        ],
+        "properties": {
+          "node_id": {"type": "string", "pattern": "^(vsr://|urn:vsr:node:)"},
+          "operator_did": {"type": "string", "pattern": "^did:digitalme:"},
+          "status": {"enum": ["controlled-pilot", "active", "suspended", "revoked"]},
+          "jurisdiction": {"type": "string", "pattern": "^[A-Z]{2}(-[A-Z0-9]{1,8})*$"},
+          "permitted_tools": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string"}},
+          "authority_refs": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string"}},
+          "evidence_sink": {"type": "string", "minLength": 3}
+        }
+      }
+    },
+    "digest": {"type": "string", "pattern": "^sha256:[a-f0-9]{64}$"},
+    "proof": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "role", "verification_method", "created", "signature"],
+      "properties": {
+        "type": {"const": "Ed25519Signature"},
+        "role": {"const": "warden-registry"},
+        "verification_method": {"type": "string", "minLength": 3},
+        "created": {"type": "string", "format": "date-time"},
+        "signature": {"type": "string", "pattern": "^[A-Za-z0-9_-]+$"}
+      }
+    }
+  }
+}

--- a/rail-mcp/server.test.ts
+++ b/rail-mcp/server.test.ts
@@ -1,12 +1,9 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import test from "node:test";
 
+import { authorizationMeta } from "./authorization";
 import { handleMcpRequest } from "./server";
-
-const NODE_ID = "vsr://mainnet/IN-KA/operational/warehouse/voi/bangalore/warehouse-001";
+import { createTestSecurityFixture, TEST_NODE_ID } from "./test-security";
 
 function resultOf(response: Record<string, unknown> | null): Record<string, unknown> {
   assert.ok(response);
@@ -15,7 +12,19 @@ function resultOf(response: Record<string, unknown> | null): Record<string, unkn
   return result as Record<string, unknown>;
 }
 
-test("declares MCP tools during initialization", async () => {
+const EXPORT_ARGS = {
+  node_id: TEST_NODE_ID,
+  from: "2026-07-21T00:00:00Z",
+  to: "2026-07-21T23:59:59Z",
+  format: "qel-ndjson",
+  redaction_policy: "strict",
+  sign: true,
+  archive: true,
+  receipt_required: true,
+  idempotency_key: "rail-1234567890abcdef",
+};
+
+test("declares authorization requirements during initialization", async () => {
   const response = await handleMcpRequest({
     jsonrpc: "2.0",
     id: 1,
@@ -26,120 +35,65 @@ test("declares MCP tools during initialization", async () => {
       clientInfo: { name: "test", version: "1" },
     },
   });
-
   const result = resultOf(response);
   assert.equal(result.protocolVersion, "2025-06-18");
-  assert.deepEqual(result.capabilities, { tools: { listChanged: false } });
+  assert.match(String(result.instructions), /authorization envelope/);
 });
 
-test("lists the six canonical rail and communications tools", async () => {
+test("lists seven canonical tools", async () => {
   const response = await handleMcpRequest({ jsonrpc: "2.0", id: 2, method: "tools/list" });
   const tools = resultOf(response).tools;
   assert.ok(Array.isArray(tools));
-  assert.equal(tools.length, 6);
-  assert.deepEqual(
-    tools.map((tool) => (tool as Record<string, unknown>).name),
-    [
-      "rail.logs.export",
-      "rail.logs.import.prepare",
-      "rail.logs.query",
-      "rail.receipts.get",
-      "comms.message.send",
-      "comms.message.status",
-    ],
-  );
+  assert.equal(tools.length, 7);
+  assert.equal((tools[0] as Record<string, unknown>).name, "rail.nodes.resolve");
 });
 
-test("node export remains a safe preview without a live adapter", async () => {
+test("denies a tool call without signed metadata", async () => {
+  const fixture = createTestSecurityFixture();
   const response = await handleMcpRequest({
     jsonrpc: "2.0",
     id: 3,
     method: "tools/call",
-    params: {
-      name: "rail.logs.export",
-      arguments: {
-        node_id: NODE_ID,
-        from: "2026-07-21T00:00:00Z",
-        to: "2026-07-21T23:59:59Z",
-        format: "qel-ndjson",
-        redaction_policy: "strict",
-        sign: true,
-        archive: true,
-        receipt_required: true,
-        idempotency_key: "rail-1234567890abcdef",
-      },
-    },
-  });
-
-  const toolResult = resultOf(response);
-  assert.equal(toolResult.isError, false);
-  const structured = toolResult.structuredContent as Record<string, unknown>;
-  assert.equal(structured.status, "preview");
-  assert.equal(structured.execution_enabled, false);
+    params: { name: "rail.logs.export", arguments: EXPORT_ARGS },
+  }, fixture.context);
+  const result = resultOf(response);
+  assert.equal(result.isError, true);
+  assert.match(JSON.stringify(result), /authorization-missing/);
 });
 
-test("rejects secrets embedded in tool arguments", async () => {
+test("resolves an exact node from the signed registry", async () => {
+  const fixture = createTestSecurityFixture();
   const response = await handleMcpRequest({
     jsonrpc: "2.0",
     id: 4,
     method: "tools/call",
     params: {
-      name: "comms.message.send",
-      arguments: {
-        channels: ["dropbox"],
-        subject: "Export ready",
-        message: "See resource link.",
-        idempotency_key: "rail-1234567890abcdef",
-        api_key: "must-not-be-accepted"
-      },
+      name: "rail.nodes.resolve",
+      arguments: { node_id: TEST_NODE_ID },
+      _meta: authorizationMeta(fixture.envelope),
     },
-  });
-
-  const toolResult = resultOf(response);
-  assert.equal(toolResult.isError, true);
-  assert.match(JSON.stringify(toolResult), /Sensitive field is not permitted/);
+  }, fixture.context);
+  const result = resultOf(response);
+  assert.equal(result.isError, false);
+  const structured = result.structuredContent as Record<string, unknown>;
+  assert.equal(structured.status, "resolved");
 });
 
-test("communications can be accepted only into an explicitly enabled controlled outbox", { concurrency: false }, async () => {
-  const directory = await mkdtemp(join(tmpdir(), "rail-mcp-test-"));
-  const oldEnabled = process.env.RAIL_MCP_EXECUTION_ENABLED;
-  const oldOutbox = process.env.RAIL_MCP_OUTBOX_DIR;
-
-  process.env.RAIL_MCP_EXECUTION_ENABLED = "true";
-  process.env.RAIL_MCP_OUTBOX_DIR = directory;
-
-  try {
-    const response = await handleMcpRequest({
-      jsonrpc: "2.0",
-      id: 5,
-      method: "tools/call",
-      params: {
-        name: "comms.message.send",
-        arguments: {
-          channels: ["notion", "dropbox"],
-          classification: "internal-operational",
-          subject: "Node export completed",
-          message: "The controlled artifact is ready.",
-          resource_links: ["rail://exports/exp-001"],
-          receipt_required: true,
-          idempotency_key: "rail-1234567890abcdef",
-        },
-      },
-    });
-
-    const toolResult = resultOf(response);
-    assert.equal(toolResult.isError, false);
-    const record = toolResult.structuredContent as Record<string, unknown>;
-    assert.equal(record.status, "accepted-to-controlled-outbox");
-    const communicationId = String(record.communication_id);
-    const persisted = JSON.parse(await readFile(join(directory, `${communicationId}.json`), "utf8"));
-    assert.equal(persisted.communication_id, communicationId);
-    assert.equal(persisted.boundary.includes("not proof"), true);
-  } finally {
-    if (oldEnabled === undefined) delete process.env.RAIL_MCP_EXECUTION_ENABLED;
-    else process.env.RAIL_MCP_EXECUTION_ENABLED = oldEnabled;
-    if (oldOutbox === undefined) delete process.env.RAIL_MCP_OUTBOX_DIR;
-    else process.env.RAIL_MCP_OUTBOX_DIR = oldOutbox;
-    await rm(directory, { recursive: true, force: true });
-  }
+test("authorized export remains preview-only", async () => {
+  const fixture = createTestSecurityFixture();
+  const response = await handleMcpRequest({
+    jsonrpc: "2.0",
+    id: 5,
+    method: "tools/call",
+    params: {
+      name: "rail.logs.export",
+      arguments: EXPORT_ARGS,
+      _meta: authorizationMeta(fixture.envelope),
+    },
+  }, fixture.context);
+  const result = resultOf(response);
+  assert.equal(result.isError, false);
+  const structured = result.structuredContent as Record<string, unknown>;
+  assert.equal(structured.status, "preview");
+  assert.equal(structured.execution_enabled, false);
 });

--- a/rail-mcp/server.test.ts
+++ b/rail-mcp/server.test.ts
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { handleMcpRequest } from "./server";
+
+const NODE_ID = "vsr://mainnet/IN-KA/operational/warehouse/voi/bangalore/warehouse-001";
+
+function resultOf(response: Record<string, unknown> | null): Record<string, unknown> {
+  assert.ok(response);
+  const result = response.result;
+  assert.ok(result && typeof result === "object" && !Array.isArray(result));
+  return result as Record<string, unknown>;
+}
+
+test("declares MCP tools during initialization", async () => {
+  const response = await handleMcpRequest({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: "2025-06-18",
+      capabilities: {},
+      clientInfo: { name: "test", version: "1" },
+    },
+  });
+
+  const result = resultOf(response);
+  assert.equal(result.protocolVersion, "2025-06-18");
+  assert.deepEqual(result.capabilities, { tools: { listChanged: false } });
+});
+
+test("lists the six canonical rail and communications tools", async () => {
+  const response = await handleMcpRequest({ jsonrpc: "2.0", id: 2, method: "tools/list" });
+  const tools = resultOf(response).tools;
+  assert.ok(Array.isArray(tools));
+  assert.equal(tools.length, 6);
+  assert.deepEqual(
+    tools.map((tool) => (tool as Record<string, unknown>).name),
+    [
+      "rail.logs.export",
+      "rail.logs.import.prepare",
+      "rail.logs.query",
+      "rail.receipts.get",
+      "comms.message.send",
+      "comms.message.status",
+    ],
+  );
+});
+
+test("node export remains a safe preview without a live adapter", async () => {
+  const response = await handleMcpRequest({
+    jsonrpc: "2.0",
+    id: 3,
+    method: "tools/call",
+    params: {
+      name: "rail.logs.export",
+      arguments: {
+        node_id: NODE_ID,
+        from: "2026-07-21T00:00:00Z",
+        to: "2026-07-21T23:59:59Z",
+        format: "qel-ndjson",
+        redaction_policy: "strict",
+        sign: true,
+        archive: true,
+        receipt_required: true,
+        idempotency_key: "rail-1234567890abcdef",
+      },
+    },
+  });
+
+  const toolResult = resultOf(response);
+  assert.equal(toolResult.isError, false);
+  const structured = toolResult.structuredContent as Record<string, unknown>;
+  assert.equal(structured.status, "preview");
+  assert.equal(structured.execution_enabled, false);
+});
+
+test("rejects secrets embedded in tool arguments", async () => {
+  const response = await handleMcpRequest({
+    jsonrpc: "2.0",
+    id: 4,
+    method: "tools/call",
+    params: {
+      name: "comms.message.send",
+      arguments: {
+        channels: ["dropbox"],
+        subject: "Export ready",
+        message: "See resource link.",
+        idempotency_key: "rail-1234567890abcdef",
+        api_key: "must-not-be-accepted"
+      },
+    },
+  });
+
+  const toolResult = resultOf(response);
+  assert.equal(toolResult.isError, true);
+  assert.match(JSON.stringify(toolResult), /Sensitive field is not permitted/);
+});
+
+test("communications can be accepted only into an explicitly enabled controlled outbox", { concurrency: false }, async () => {
+  const directory = await mkdtemp(join(tmpdir(), "rail-mcp-test-"));
+  const oldEnabled = process.env.RAIL_MCP_EXECUTION_ENABLED;
+  const oldOutbox = process.env.RAIL_MCP_OUTBOX_DIR;
+
+  process.env.RAIL_MCP_EXECUTION_ENABLED = "true";
+  process.env.RAIL_MCP_OUTBOX_DIR = directory;
+
+  try {
+    const response = await handleMcpRequest({
+      jsonrpc: "2.0",
+      id: 5,
+      method: "tools/call",
+      params: {
+        name: "comms.message.send",
+        arguments: {
+          channels: ["notion", "dropbox"],
+          classification: "internal-operational",
+          subject: "Node export completed",
+          message: "The controlled artifact is ready.",
+          resource_links: ["rail://exports/exp-001"],
+          receipt_required: true,
+          idempotency_key: "rail-1234567890abcdef",
+        },
+      },
+    });
+
+    const toolResult = resultOf(response);
+    assert.equal(toolResult.isError, false);
+    const record = toolResult.structuredContent as Record<string, unknown>;
+    assert.equal(record.status, "accepted-to-controlled-outbox");
+    const communicationId = String(record.communication_id);
+    const persisted = JSON.parse(await readFile(join(directory, `${communicationId}.json`), "utf8"));
+    assert.equal(persisted.communication_id, communicationId);
+    assert.equal(persisted.boundary.includes("not proof"), true);
+  } finally {
+    if (oldEnabled === undefined) delete process.env.RAIL_MCP_EXECUTION_ENABLED;
+    else process.env.RAIL_MCP_EXECUTION_ENABLED = oldEnabled;
+    if (oldOutbox === undefined) delete process.env.RAIL_MCP_OUTBOX_DIR;
+    else process.env.RAIL_MCP_OUTBOX_DIR = oldOutbox;
+    await rm(directory, { recursive: true, force: true });
+  }
+});

--- a/rail-mcp/server.ts
+++ b/rail-mcp/server.ts
@@ -1,0 +1,327 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import * as readline from "node:readline";
+
+type JsonObject = Record<string, unknown>;
+type JsonRpcId = string | number | null;
+
+type JsonRpcRequest = {
+  jsonrpc: "2.0";
+  id?: JsonRpcId;
+  method: string;
+  params?: JsonObject;
+};
+
+type ToolContract = {
+  name: string;
+  title?: string;
+  description?: string;
+  inputSchema: JsonObject;
+};
+
+type ContractRegistry = {
+  protocol_version: string;
+  contract_version: string;
+  tools: ToolContract[];
+};
+
+const CONTRACTS_URL = new URL("./tool-contracts.v0.1.json", import.meta.url);
+const SERVER_NAME = "qel-pinyin-rail-mcp";
+const SERVER_VERSION = "0.1.0";
+
+export async function loadToolContracts(): Promise<ContractRegistry> {
+  return JSON.parse(await readFile(CONTRACTS_URL, "utf8")) as ContractRegistry;
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  if (value !== null && typeof value === "object") {
+    const object = value as JsonObject;
+    return `{${Object.keys(object)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableJson(object[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function stableId(prefix: string, payload: unknown): string {
+  const digest = createHash("sha256").update(stableJson(payload)).digest("hex");
+  return `${prefix}_${digest.slice(0, 24)}`;
+}
+
+function jsonRpcResult(id: JsonRpcId | undefined, result: unknown): JsonObject {
+  return { jsonrpc: "2.0", id: id ?? null, result };
+}
+
+function jsonRpcError(id: JsonRpcId | undefined, code: number, message: string, data?: unknown): JsonObject {
+  return {
+    jsonrpc: "2.0",
+    id: id ?? null,
+    error: { code, message, ...(data === undefined ? {} : { data }) },
+  };
+}
+
+function toolError(message: string, details?: JsonObject): JsonObject {
+  return {
+    content: [{ type: "text", text: message }],
+    structuredContent: { status: "rejected", message, ...(details ?? {}) },
+    isError: true,
+  };
+}
+
+function assertNoSensitiveKeys(value: unknown, path = "arguments"): void {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => assertNoSensitiveKeys(item, `${path}[${index}]`));
+    return;
+  }
+  if (value === null || typeof value !== "object") return;
+
+  for (const [key, child] of Object.entries(value as JsonObject)) {
+    if (/(secret|password|token|api[_-]?key|private[_-]?key)/i.test(key)) {
+      throw new Error(`Sensitive field is not permitted in MCP arguments: ${path}.${key}`);
+    }
+    assertNoSensitiveKeys(child, `${path}.${key}`);
+  }
+}
+
+function validateSchema(value: unknown, schema: JsonObject, path = "arguments"): string[] {
+  const errors: string[] = [];
+  const type = schema.type;
+
+  if (type === "object") {
+    if (value === null || typeof value !== "object" || Array.isArray(value)) {
+      return [`${path} must be an object`];
+    }
+    const object = value as JsonObject;
+    const properties = (schema.properties ?? {}) as Record<string, JsonObject>;
+    const required = (schema.required ?? []) as string[];
+
+    for (const name of required) {
+      if (!(name in object)) errors.push(`${path}.${name} is required`);
+    }
+    if (schema.additionalProperties === false) {
+      for (const name of Object.keys(object)) {
+        if (!(name in properties)) errors.push(`${path}.${name} is not allowed`);
+      }
+    }
+    for (const [name, child] of Object.entries(object)) {
+      if (properties[name]) errors.push(...validateSchema(child, properties[name], `${path}.${name}`));
+    }
+    return errors;
+  }
+
+  if (type === "array") {
+    if (!Array.isArray(value)) return [`${path} must be an array`];
+    const minItems = schema.minItems as number | undefined;
+    if (minItems !== undefined && value.length < minItems) errors.push(`${path} must contain at least ${minItems} item(s)`);
+    if (schema.uniqueItems === true && new Set(value.map(stableJson)).size !== value.length) {
+      errors.push(`${path} must contain unique items`);
+    }
+    const items = schema.items as JsonObject | undefined;
+    if (items) value.forEach((item, index) => errors.push(...validateSchema(item, items, `${path}[${index}]`)));
+    return errors;
+  }
+
+  if (type === "string") {
+    if (typeof value !== "string") return [`${path} must be a string`];
+    const minLength = schema.minLength as number | undefined;
+    const maxLength = schema.maxLength as number | undefined;
+    if (minLength !== undefined && value.length < minLength) errors.push(`${path} is too short`);
+    if (maxLength !== undefined && value.length > maxLength) errors.push(`${path} is too long`);
+    if (typeof schema.pattern === "string" && !new RegExp(schema.pattern).test(value)) {
+      errors.push(`${path} does not match the required pattern`);
+    }
+  } else if (type === "boolean" && typeof value !== "boolean") {
+    errors.push(`${path} must be a boolean`);
+  } else if (type === "integer") {
+    if (!Number.isInteger(value)) return [`${path} must be an integer`];
+    const number = value as number;
+    if (typeof schema.minimum === "number" && number < schema.minimum) errors.push(`${path} is below minimum`);
+    if (typeof schema.maximum === "number" && number > schema.maximum) errors.push(`${path} is above maximum`);
+  }
+
+  if (Array.isArray(schema.enum) && !schema.enum.some((candidate) => stableJson(candidate) === stableJson(value))) {
+    errors.push(`${path} is not an allowed value`);
+  }
+  if ("const" in schema && stableJson(schema.const) !== stableJson(value)) {
+    errors.push(`${path} must equal ${JSON.stringify(schema.const)}`);
+  }
+  return errors;
+}
+
+function resourceLink(uri: string, name: string, mimeType = "application/json"): JsonObject {
+  return { type: "resource_link", uri, name, mimeType };
+}
+
+function previewResult(tool: string, args: JsonObject): JsonObject {
+  const receiptId = stableId("rcpt", { tool, args });
+  const operationId = stableId("op", { tool, args });
+  const resources = [
+    resourceLink(`rail://operations/${operationId}`, `${tool} operation`),
+    resourceLink(`rail://receipts/${receiptId}`, "Rail operation receipt"),
+  ];
+
+  return {
+    content: [
+      { type: "text", text: `${tool} compiled in safe preview mode. No node or external destination was modified.` },
+      ...resources,
+    ],
+    structuredContent: {
+      status: "preview",
+      operation_id: operationId,
+      receipt_id: receiptId,
+      tool,
+      execution_enabled: false,
+      resource_uris: resources.map((item) => item.uri),
+    },
+    isError: false,
+  };
+}
+
+async function sendCommunication(args: JsonObject): Promise<JsonObject> {
+  const executionEnabled = process.env.RAIL_MCP_EXECUTION_ENABLED === "true";
+  if (!executionEnabled) return previewResult("comms.message.send", args);
+
+  if (args.classification === "confidential" && process.env.RAIL_MCP_CONFIDENTIAL_ENABLED !== "true") {
+    return toolError("Confidential communications require RAIL_MCP_CONFIDENTIAL_ENABLED=true");
+  }
+
+  const outbox = process.env.RAIL_MCP_OUTBOX_DIR;
+  if (!outbox) return toolError("Execution is enabled but RAIL_MCP_OUTBOX_DIR is not configured");
+
+  const communicationId = stableId("comm", args);
+  const receiptId = stableId("rcpt", { communicationId, args });
+  const record = {
+    schema: "org.believerscommon.rail.communication.v1",
+    communication_id: communicationId,
+    receipt_id: receiptId,
+    status: "accepted-to-controlled-outbox",
+    recorded_at: new Date().toISOString(),
+    channels: args.channels,
+    classification: args.classification,
+    subject: args.subject,
+    message: args.message,
+    resource_links: args.resource_links ?? [],
+    idempotency_key: args.idempotency_key,
+    boundary: "Outbox acceptance is not proof that an external channel delivered the message.",
+  };
+
+  await mkdir(outbox, { recursive: true });
+  await writeFile(join(outbox, `${communicationId}.json`), `${JSON.stringify(record, null, 2)}\n`, {
+    encoding: "utf8",
+    flag: "wx",
+  }).catch(async (error: NodeJS.ErrnoException) => {
+    if (error.code !== "EEXIST") throw error;
+  });
+
+  return {
+    content: [
+      { type: "text", text: `Communication ${communicationId} accepted to the controlled outbox.` },
+      resourceLink(`rail://communications/${communicationId}`, "Communication record"),
+      resourceLink(`rail://receipts/${receiptId}`, "Communication receipt"),
+    ],
+    structuredContent: record,
+    isError: false,
+  };
+}
+
+async function communicationStatus(args: JsonObject): Promise<JsonObject> {
+  const outbox = process.env.RAIL_MCP_OUTBOX_DIR;
+  if (!outbox) return toolError("RAIL_MCP_OUTBOX_DIR is not configured");
+  const id = String(args.communication_id);
+  if (!/^comm_[a-f0-9]{24}$/.test(id)) return toolError("Invalid communication_id");
+
+  try {
+    const record = JSON.parse(await readFile(join(outbox, `${id}.json`), "utf8")) as JsonObject;
+    return {
+      content: [
+        { type: "text", text: `Communication ${id}: ${String(record.status)}` },
+        resourceLink(`rail://communications/${id}`, "Communication record"),
+      ],
+      structuredContent: record,
+      isError: false,
+    };
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") return toolError(`Communication not found: ${id}`);
+    throw error;
+  }
+}
+
+async function callTool(contract: ToolContract, args: JsonObject): Promise<JsonObject> {
+  assertNoSensitiveKeys(args);
+  const validationErrors = validateSchema(args, contract.inputSchema);
+  if (validationErrors.length > 0) return toolError("Tool arguments failed validation", { validation_errors: validationErrors });
+
+  if (contract.name === "comms.message.send") return sendCommunication(args);
+  if (contract.name === "comms.message.status") return communicationStatus(args);
+
+  return previewResult(contract.name, args);
+}
+
+export async function handleMcpRequest(request: JsonRpcRequest): Promise<JsonObject | null> {
+  const registry = await loadToolContracts();
+
+  if (request.method === "notifications/initialized") return null;
+  if (request.method === "initialize") {
+    return jsonRpcResult(request.id, {
+      protocolVersion: registry.protocol_version,
+      capabilities: { tools: { listChanged: false } },
+      serverInfo: {
+        name: SERVER_NAME,
+        version: SERVER_VERSION,
+        description: "Safe Pinyin rail-node and communications command server",
+      },
+      instructions: "Node operations run in preview mode. Communications require explicit environment activation and use a controlled local outbox.",
+    });
+  }
+  if (request.method === "ping") return jsonRpcResult(request.id, {});
+  if (request.method === "tools/list") {
+    return jsonRpcResult(request.id, {
+      tools: registry.tools.map(({ name, title, description, inputSchema }) => ({
+        name,
+        title,
+        description,
+        inputSchema,
+      })),
+    });
+  }
+  if (request.method === "tools/call") {
+    const params = request.params ?? {};
+    const name = params.name;
+    const args = params.arguments;
+    if (typeof name !== "string") return jsonRpcError(request.id, -32602, "tools/call requires params.name");
+    if (args === null || typeof args !== "object" || Array.isArray(args)) {
+      return jsonRpcError(request.id, -32602, "tools/call requires object params.arguments");
+    }
+    const contract = registry.tools.find((candidate) => candidate.name === name);
+    if (!contract) return jsonRpcError(request.id, -32602, `Unknown tool: ${name}`);
+    return jsonRpcResult(request.id, await callTool(contract, args as JsonObject));
+  }
+
+  return jsonRpcError(request.id, -32601, `Method not found: ${request.method}`);
+}
+
+export async function runStdioServer(): Promise<void> {
+  const input = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
+  for await (const line of input) {
+    if (!line.trim()) continue;
+    try {
+      const request = JSON.parse(line) as JsonRpcRequest;
+      const response = await handleMcpRequest(request);
+      if (response) process.stdout.write(`${JSON.stringify(response)}\n`);
+    } catch (error) {
+      process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+      process.stdout.write(`${JSON.stringify(jsonRpcError(null, -32700, "Parse error"))}\n`);
+    }
+  }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  await runStdioServer();
+}

--- a/rail-mcp/server.ts
+++ b/rail-mcp/server.ts
@@ -212,12 +212,17 @@ async function sendCommunication(args: JsonObject): Promise<JsonObject> {
   };
 
   await mkdir(outbox, { recursive: true });
-  await writeFile(join(outbox, `${communicationId}.json`), `${JSON.stringify(record, null, 2)}\n`, {
-    encoding: "utf8",
-    flag: "wx",
-  }).catch(async (error: NodeJS.ErrnoException) => {
-    if (error.code !== "EEXIST") throw error;
-  });
+  let persistedRecord = record;
+  try {
+    await writeFile(join(outbox, `${communicationId}.json`), `${JSON.stringify(record, null, 2)}\n`, {
+      encoding: "utf8",
+      flag: "wx",
+    });
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== "EEXIST") throw error;
+    persistedRecord = JSON.parse(await readFile(join(outbox, `${communicationId}.json`), "utf8"));
+  }
 
   return {
     content: [
@@ -225,7 +230,7 @@ async function sendCommunication(args: JsonObject): Promise<JsonObject> {
       resourceLink(`rail://communications/${communicationId}`, "Communication record"),
       resourceLink(`rail://receipts/${receiptId}`, "Communication receipt"),
     ],
-    structuredContent: record,
+    structuredContent: persistedRecord,
     isError: false,
   };
 }
@@ -254,7 +259,12 @@ async function communicationStatus(args: JsonObject): Promise<JsonObject> {
 }
 
 async function callTool(contract: ToolContract, args: JsonObject): Promise<JsonObject> {
-  assertNoSensitiveKeys(args);
+  try {
+    assertNoSensitiveKeys(args);
+  } catch (error) {
+    return toolError(error instanceof Error ? error.message : String(error));
+  }
+
   const validationErrors = validateSchema(args, contract.inputSchema);
   if (validationErrors.length > 0) return toolError("Tool arguments failed validation", { validation_errors: validationErrors });
 

--- a/rail-mcp/server.ts
+++ b/rail-mcp/server.ts
@@ -6,6 +6,14 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import * as readline from "node:readline";
 
+import {
+  type AuthorizationDecision,
+  type RailNodeRecord,
+  type SecurityContext,
+  authorizeToolCall,
+  loadSecurityContextFromEnvironment,
+} from "./authorization";
+
 type JsonObject = Record<string, unknown>;
 type JsonRpcId = string | number | null;
 
@@ -31,7 +39,7 @@ type ContractRegistry = {
 
 const CONTRACTS_URL = new URL("./tool-contracts.v0.1.json", import.meta.url);
 const SERVER_NAME = "qel-pinyin-rail-mcp";
-const SERVER_VERSION = "0.1.0";
+const SERVER_VERSION = "0.2.0";
 
 export async function loadToolContracts(): Promise<ContractRegistry> {
   return JSON.parse(await readFile(CONTRACTS_URL, "utf8")) as ContractRegistry;
@@ -52,6 +60,10 @@ function stableJson(value: unknown): string {
 function stableId(prefix: string, payload: unknown): string {
   const digest = createHash("sha256").update(stableJson(payload)).digest("hex");
   return `${prefix}_${digest.slice(0, 24)}`;
+}
+
+function isObject(value: unknown): value is JsonObject {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 function jsonRpcResult(id: JsonRpcId | undefined, result: unknown): JsonObject {
@@ -158,17 +170,18 @@ function resourceLink(uri: string, name: string, mimeType = "application/json"):
   return { type: "resource_link", uri, name, mimeType };
 }
 
-function previewResult(tool: string, args: JsonObject): JsonObject {
-  const receiptId = stableId("rcpt", { tool, args });
-  const operationId = stableId("op", { tool, args });
+function previewResult(tool: string, args: JsonObject, authorization: AuthorizationDecision): JsonObject {
+  const receiptId = stableId("rcpt", { tool, args, authorization_id: authorization.authorization_id });
+  const operationId = stableId("op", { tool, args, authorization_id: authorization.authorization_id });
   const resources = [
     resourceLink(`rail://operations/${operationId}`, `${tool} operation`),
     resourceLink(`rail://receipts/${receiptId}`, "Rail operation receipt"),
+    resourceLink(`rail://authorizations/${authorization.authorization_id}`, "Authorization decision"),
   ];
 
   return {
     content: [
-      { type: "text", text: `${tool} compiled in safe preview mode. No node or external destination was modified.` },
+      { type: "text", text: `${tool} authorized and compiled in safe preview mode. No node or external destination was modified.` },
       ...resources,
     ],
     structuredContent: {
@@ -177,25 +190,48 @@ function previewResult(tool: string, args: JsonObject): JsonObject {
       receipt_id: receiptId,
       tool,
       execution_enabled: false,
+      authorization,
       resource_uris: resources.map((item) => item.uri),
     },
     isError: false,
   };
 }
 
-async function sendCommunication(args: JsonObject): Promise<JsonObject> {
+function resolveNodeResult(node: RailNodeRecord, authorization: AuthorizationDecision): JsonObject {
+  const resources = [
+    resourceLink(`rail://nodes/${encodeURIComponent(node.node_id)}`, "Signed rail node"),
+    resourceLink(`rail://authorizations/${authorization.authorization_id}`, "Authorization decision"),
+  ];
+  return {
+    content: [
+      { type: "text", text: `Node ${node.node_id} resolved from signed registry ${authorization.registry_id}.` },
+      ...resources,
+    ],
+    structuredContent: {
+      status: "resolved",
+      node,
+      authorization,
+      resource_uris: resources.map((item) => item.uri),
+    },
+    isError: false,
+  };
+}
+
+async function sendCommunication(args: JsonObject, authorization: AuthorizationDecision): Promise<JsonObject> {
   const executionEnabled = process.env.RAIL_MCP_EXECUTION_ENABLED === "true";
-  if (!executionEnabled) return previewResult("comms.message.send", args);
+  if (!executionEnabled) return previewResult("comms.message.send", args, authorization);
 
   if (args.classification === "confidential" && process.env.RAIL_MCP_CONFIDENTIAL_ENABLED !== "true") {
-    return toolError("Confidential communications require RAIL_MCP_CONFIDENTIAL_ENABLED=true");
+    return toolError("Confidential communications require RAIL_MCP_CONFIDENTIAL_ENABLED=true", {
+      authorization: { status: "authorized", decision_id: authorization.decision_id },
+    });
   }
 
   const outbox = process.env.RAIL_MCP_OUTBOX_DIR;
   if (!outbox) return toolError("Execution is enabled but RAIL_MCP_OUTBOX_DIR is not configured");
 
-  const communicationId = stableId("comm", args);
-  const receiptId = stableId("rcpt", { communicationId, args });
+  const communicationId = stableId("comm", { args, authorization_id: authorization.authorization_id });
+  const receiptId = stableId("rcpt", { communicationId, args, authorization_id: authorization.authorization_id });
   const record = {
     schema: "org.believerscommon.rail.communication.v1",
     communication_id: communicationId,
@@ -208,6 +244,7 @@ async function sendCommunication(args: JsonObject): Promise<JsonObject> {
     message: args.message,
     resource_links: args.resource_links ?? [],
     idempotency_key: args.idempotency_key,
+    authorization,
     boundary: "Outbox acceptance is not proof that an external channel delivered the message.",
   };
 
@@ -229,13 +266,14 @@ async function sendCommunication(args: JsonObject): Promise<JsonObject> {
       { type: "text", text: `Communication ${communicationId} accepted to the controlled outbox.` },
       resourceLink(`rail://communications/${communicationId}`, "Communication record"),
       resourceLink(`rail://receipts/${receiptId}`, "Communication receipt"),
+      resourceLink(`rail://authorizations/${authorization.authorization_id}`, "Authorization decision"),
     ],
     structuredContent: persistedRecord,
     isError: false,
   };
 }
 
-async function communicationStatus(args: JsonObject): Promise<JsonObject> {
+async function communicationStatus(args: JsonObject, authorization: AuthorizationDecision): Promise<JsonObject> {
   const outbox = process.env.RAIL_MCP_OUTBOX_DIR;
   if (!outbox) return toolError("RAIL_MCP_OUTBOX_DIR is not configured");
   const id = String(args.communication_id);
@@ -247,8 +285,9 @@ async function communicationStatus(args: JsonObject): Promise<JsonObject> {
       content: [
         { type: "text", text: `Communication ${id}: ${String(record.status)}` },
         resourceLink(`rail://communications/${id}`, "Communication record"),
+        resourceLink(`rail://authorizations/${authorization.authorization_id}`, "Authorization decision"),
       ],
-      structuredContent: record,
+      structuredContent: { ...record, read_authorization: authorization },
       isError: false,
     };
   } catch (error) {
@@ -258,7 +297,12 @@ async function communicationStatus(args: JsonObject): Promise<JsonObject> {
   }
 }
 
-async function callTool(contract: ToolContract, args: JsonObject): Promise<JsonObject> {
+async function callTool(
+  contract: ToolContract,
+  args: JsonObject,
+  meta: JsonObject | undefined,
+  providedSecurityContext?: SecurityContext,
+): Promise<JsonObject> {
   try {
     assertNoSensitiveKeys(args);
   } catch (error) {
@@ -268,13 +312,36 @@ async function callTool(contract: ToolContract, args: JsonObject): Promise<JsonO
   const validationErrors = validateSchema(args, contract.inputSchema);
   if (validationErrors.length > 0) return toolError("Tool arguments failed validation", { validation_errors: validationErrors });
 
-  if (contract.name === "comms.message.send") return sendCommunication(args);
-  if (contract.name === "comms.message.status") return communicationStatus(args);
+  let securityContext: SecurityContext;
+  try {
+    securityContext = providedSecurityContext ?? await loadSecurityContextFromEnvironment();
+  } catch (error) {
+    return toolError(error instanceof Error ? error.message : String(error), {
+      authorization: { status: "denied", code: "security-context-unavailable" },
+    });
+  }
 
-  return previewResult(contract.name, args);
+  const authorization = authorizeToolCall(contract.name, args, meta, securityContext);
+  if (!authorization.ok) {
+    return toolError(authorization.message, {
+      authorization: { status: "denied", code: authorization.code },
+    });
+  }
+
+  if (contract.name === "rail.nodes.resolve") {
+    if (!authorization.node) return toolError("Authorized node resolution returned no node");
+    return resolveNodeResult(authorization.node, authorization.decision);
+  }
+  if (contract.name === "comms.message.send") return sendCommunication(args, authorization.decision);
+  if (contract.name === "comms.message.status") return communicationStatus(args, authorization.decision);
+
+  return previewResult(contract.name, args, authorization.decision);
 }
 
-export async function handleMcpRequest(request: JsonRpcRequest): Promise<JsonObject | null> {
+export async function handleMcpRequest(
+  request: JsonRpcRequest,
+  securityContext?: SecurityContext,
+): Promise<JsonObject | null> {
   const registry = await loadToolContracts();
 
   if (request.method === "notifications/initialized") return null;
@@ -285,9 +352,9 @@ export async function handleMcpRequest(request: JsonRpcRequest): Promise<JsonObj
       serverInfo: {
         name: SERVER_NAME,
         version: SERVER_VERSION,
-        description: "Safe Pinyin rail-node and communications command server",
+        description: "Authorized Pinyin rail-node and controlled communications command server",
       },
-      instructions: "Node operations run in preview mode. Communications require explicit environment activation and use a controlled local outbox.",
+      instructions: "Every tools/call requires a dual-signed DigitalMe/Warden authorization envelope bound to a signed node-registry digest. Node operations remain preview-only.",
     });
   }
   if (request.method === "ping") return jsonRpcResult(request.id, {});
@@ -298,6 +365,7 @@ export async function handleMcpRequest(request: JsonRpcRequest): Promise<JsonObj
         title,
         description,
         inputSchema,
+        _meta: { "org.believerscommon/authorization-required": true },
       })),
     });
   }
@@ -305,13 +373,13 @@ export async function handleMcpRequest(request: JsonRpcRequest): Promise<JsonObj
     const params = request.params ?? {};
     const name = params.name;
     const args = params.arguments;
+    const meta = params._meta;
     if (typeof name !== "string") return jsonRpcError(request.id, -32602, "tools/call requires params.name");
-    if (args === null || typeof args !== "object" || Array.isArray(args)) {
-      return jsonRpcError(request.id, -32602, "tools/call requires object params.arguments");
-    }
+    if (!isObject(args)) return jsonRpcError(request.id, -32602, "tools/call requires object params.arguments");
+    if (meta !== undefined && !isObject(meta)) return jsonRpcError(request.id, -32602, "tools/call params._meta must be an object");
     const contract = registry.tools.find((candidate) => candidate.name === name);
     if (!contract) return jsonRpcError(request.id, -32602, `Unknown tool: ${name}`);
-    return jsonRpcResult(request.id, await callTool(contract, args as JsonObject));
+    return jsonRpcResult(request.id, await callTool(contract, args, meta as JsonObject | undefined, securityContext));
   }
 
   return jsonRpcError(request.id, -32601, `Method not found: ${request.method}`);

--- a/rail-mcp/test-security.ts
+++ b/rail-mcp/test-security.ts
@@ -1,0 +1,160 @@
+import { generateKeyPairSync, sign } from "node:crypto";
+
+import {
+  type AuthorizationEnvelope,
+  type SecurityContext,
+  type SignedNodeRegistry,
+  type TrustStore,
+  authorizationSigningPayload,
+  calculateRegistryDigest,
+  canonicalJson,
+  registrySigningPayload,
+} from "./authorization";
+
+export const TEST_NODE_ID = "vsr://mainnet/IN-KA/operational/warehouse/voi/bangalore/warehouse-001";
+
+function iso(date: Date): string {
+  return date.toISOString();
+}
+
+function signPayload(payload: Record<string, unknown>, privateKey: ReturnType<typeof generateKeyPairSync>["privateKey"]): string {
+  return sign(null, Buffer.from(canonicalJson(payload), "utf8"), privateKey).toString("base64url");
+}
+
+export function createTestSecurityFixture(options?: {
+  now?: Date;
+  nodeStatus?: "controlled-pilot" | "active" | "suspended" | "revoked";
+  authorizationExpiresAt?: Date;
+  registryExpiresAt?: Date;
+  grantedTools?: string[];
+  grantedNodes?: string[];
+  grantedChannels?: string[];
+  grantedClassifications?: string[];
+  maxExportSeconds?: number;
+  maxQueryLimit?: number;
+}): {
+  context: SecurityContext;
+  envelope: AuthorizationEnvelope;
+  registry: SignedNodeRegistry;
+  trustStore: TrustStore;
+} {
+  const now = options?.now ?? new Date("2026-07-21T12:00:00Z");
+  const actor = generateKeyPairSync("ed25519");
+  const policy = generateKeyPairSync("ed25519");
+  const registryAuthority = generateKeyPairSync("ed25519");
+
+  const trustStore: TrustStore = {
+    schema: "org.believerscommon.rail.trust-store.v1",
+    version: "test-1",
+    keys: [
+      {
+        verification_method: "did:digitalme:operator-001#key-1",
+        role: "digitalme-actor",
+        public_key_pem: actor.publicKey.export({ type: "spki", format: "pem" }).toString(),
+        status: "active",
+      },
+      {
+        verification_method: "urn:warden:policy:test#key-1",
+        role: "warden-policy",
+        public_key_pem: policy.publicKey.export({ type: "spki", format: "pem" }).toString(),
+        status: "active",
+      },
+      {
+        verification_method: "urn:warden:registry:test#key-1",
+        role: "warden-registry",
+        public_key_pem: registryAuthority.publicKey.export({ type: "spki", format: "pem" }).toString(),
+        status: "active",
+      },
+    ],
+  };
+
+  const registry: SignedNodeRegistry = {
+    schema: "org.believerscommon.rail.node-registry.v1",
+    registry_id: "registry_test_001",
+    version: "0.1.0",
+    issued_at: iso(new Date(now.getTime() - 60_000)),
+    expires_at: iso(options?.registryExpiresAt ?? new Date(now.getTime() + 3_600_000)),
+    nodes: [
+      {
+        node_id: TEST_NODE_ID,
+        operator_did: "did:digitalme:voi-warehouse-001",
+        status: options?.nodeStatus ?? "controlled-pilot",
+        jurisdiction: "IN-KA",
+        permitted_tools: [
+          "rail.nodes.resolve",
+          "rail.logs.export",
+          "rail.logs.import.prepare",
+          "rail.logs.query",
+        ],
+        authority_refs: ["urn:empireos:license:warehouse-receiving-test"],
+        evidence_sink: "urn:riveros:node:receipt-test",
+      },
+    ],
+    digest: "",
+    proof: {
+      type: "Ed25519Signature",
+      role: "warden-registry",
+      verification_method: "urn:warden:registry:test#key-1",
+      created: iso(now),
+      signature: "pending",
+    },
+  };
+  registry.digest = calculateRegistryDigest(registry);
+  registry.proof.signature = signPayload(registrySigningPayload(registry), registryAuthority.privateKey);
+
+  const envelope: AuthorizationEnvelope = {
+    schema: "org.believerscommon.rail.authorization.v1",
+    authorization_id: "auth_test_operator_001",
+    issuer_did: "did:digitalme:operator-001",
+    subject_did: "did:digitalme:operator-001",
+    audience: "qel-pinyin-rail-mcp",
+    issued_at: iso(new Date(now.getTime() - 30_000)),
+    not_before: iso(new Date(now.getTime() - 20_000)),
+    expires_at: iso(options?.authorizationExpiresAt ?? new Date(now.getTime() + 600_000)),
+    nonce: "test-nonce-0000000000001",
+    registry_digest: registry.digest,
+    grants: {
+      tools: options?.grantedTools ?? [
+        "rail.nodes.resolve",
+        "rail.logs.export",
+        "rail.logs.import.prepare",
+        "rail.logs.query",
+        "rail.receipts.get",
+        "comms.message.send",
+        "comms.message.status",
+      ],
+      nodes: options?.grantedNodes ?? [TEST_NODE_ID],
+      channels: options?.grantedChannels ?? ["notion", "dropbox"],
+      classifications: options?.grantedClassifications ?? ["internal-operational"],
+      max_export_seconds: options?.maxExportSeconds ?? 86_400,
+      max_query_limit: options?.maxQueryLimit ?? 500,
+    },
+    proofs: [
+      {
+        type: "Ed25519Signature",
+        role: "digitalme-actor",
+        verification_method: "did:digitalme:operator-001#key-1",
+        created: iso(now),
+        signature: "pending",
+      },
+      {
+        type: "Ed25519Signature",
+        role: "warden-policy",
+        verification_method: "urn:warden:policy:test#key-1",
+        created: iso(now),
+        signature: "pending",
+      },
+    ],
+  };
+
+  const authorizationPayload = authorizationSigningPayload(envelope);
+  envelope.proofs[0].signature = signPayload(authorizationPayload, actor.privateKey);
+  envelope.proofs[1].signature = signPayload(authorizationPayload, policy.privateKey);
+
+  return {
+    context: { trustStore, registry, now },
+    envelope,
+    registry,
+    trustStore,
+  };
+}

--- a/rail-mcp/tool-contracts.v0.1.json
+++ b/rail-mcp/tool-contracts.v0.1.json
@@ -1,8 +1,26 @@
 {
   "protocol_version": "2025-06-18",
-  "contract_version": "0.1.0",
+  "contract_version": "0.2.0",
   "status": "draft",
+  "authorization": {
+    "metadata_key": "org.believerscommon/authorization",
+    "required_proofs": ["digitalme-actor", "warden-policy"],
+    "registry_binding": "sha256 canonical node-registry digest"
+  },
   "tools": [
+    {
+      "name": "rail.nodes.resolve",
+      "title": "Resolve signed rail node",
+      "description": "Resolve one exact node from the signed Warden registry after DigitalMe and Warden authorization checks.",
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["node_id"],
+        "properties": {
+          "node_id": {"type": "string", "pattern": "^(vsr://|urn:vsr:node:)"}
+        }
+      }
+    },
     {
       "name": "rail.logs.export",
       "title": "Export rail-node logs",
@@ -27,7 +45,7 @@
     {
       "name": "rail.logs.import.prepare",
       "title": "Prepare rail-node log import",
-      "description": "Validate provenance and digest, then place an import into quarantine. This tool never commits authoritative evidence.",
+      "description": "Validate provenance and digest, then place an authorized import into quarantine. This tool never commits authoritative evidence.",
       "inputSchema": {
         "type": "object",
         "additionalProperties": false,
@@ -46,7 +64,7 @@
     {
       "name": "rail.logs.query",
       "title": "Query rail-node logs",
-      "description": "Return a redacted query plan or delegated node-log result.",
+      "description": "Return an authorized redacted query plan or delegated node-log result.",
       "inputSchema": {
         "type": "object",
         "additionalProperties": false,
@@ -63,7 +81,7 @@
     {
       "name": "rail.receipts.get",
       "title": "Read rail receipt",
-      "description": "Read a receipt by its stable identifier.",
+      "description": "Read a receipt by its stable identifier under an authorized capability.",
       "inputSchema": {
         "type": "object",
         "additionalProperties": false,
@@ -74,7 +92,7 @@
     {
       "name": "comms.message.send",
       "title": "Send controlled communication",
-      "description": "Create a classified communication request and route it through configured adapters.",
+      "description": "Create an authorized classified communication request and route it through configured adapters.",
       "inputSchema": {
         "type": "object",
         "additionalProperties": false,
@@ -98,7 +116,7 @@
     {
       "name": "comms.message.status",
       "title": "Read communication status",
-      "description": "Read the status of a communication request from the controlled outbox.",
+      "description": "Read an authorized communication request status from the controlled outbox.",
       "inputSchema": {
         "type": "object",
         "additionalProperties": false,

--- a/rail-mcp/tool-contracts.v0.1.json
+++ b/rail-mcp/tool-contracts.v0.1.json
@@ -1,0 +1,110 @@
+{
+  "protocol_version": "2025-06-18",
+  "contract_version": "0.1.0",
+  "status": "draft",
+  "tools": [
+    {
+      "name": "rail.logs.export",
+      "title": "Export rail-node logs",
+      "description": "Prepare an authorized, redacted node-log export and return resource and receipt references.",
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["node_id", "from", "to", "format", "redaction_policy", "idempotency_key"],
+        "properties": {
+          "node_id": {"type": "string", "pattern": "^(vsr://|urn:vsr:node:)"},
+          "from": {"type": "string", "format": "date-time"},
+          "to": {"type": "string", "format": "date-time"},
+          "format": {"enum": ["qel-ndjson", "jsonl", "zip"]},
+          "redaction_policy": {"enum": ["strict", "operational", "auditor"]},
+          "sign": {"type": "boolean"},
+          "archive": {"type": "boolean"},
+          "receipt_required": {"type": "boolean"},
+          "idempotency_key": {"type": "string", "minLength": 16}
+        }
+      }
+    },
+    {
+      "name": "rail.logs.import.prepare",
+      "title": "Prepare rail-node log import",
+      "description": "Validate provenance and digest, then place an import into quarantine. This tool never commits authoritative evidence.",
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["node_id", "source", "expected_digest", "idempotency_key"],
+        "properties": {
+          "node_id": {"type": "string", "pattern": "^(vsr://|urn:vsr:node:)"},
+          "source": {"type": "string"},
+          "expected_digest": {"type": "string", "pattern": "^sha256:[a-f0-9]{64}$"},
+          "validate": {"type": "boolean"},
+          "quarantine": {"const": true},
+          "receipt_required": {"type": "boolean"},
+          "idempotency_key": {"type": "string", "minLength": 16}
+        }
+      }
+    },
+    {
+      "name": "rail.logs.query",
+      "title": "Query rail-node logs",
+      "description": "Return a redacted query plan or delegated node-log result.",
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["node_id"],
+        "properties": {
+          "node_id": {"type": "string", "pattern": "^(vsr://|urn:vsr:node:)"},
+          "time_window": {"type": "string"},
+          "levels": {"type": "array", "items": {"type": "string"}},
+          "limit": {"type": "integer", "minimum": 1, "maximum": 10000},
+          "redaction_policy": {"enum": ["strict", "operational", "auditor"]}
+        }
+      }
+    },
+    {
+      "name": "rail.receipts.get",
+      "title": "Read rail receipt",
+      "description": "Read a receipt by its stable identifier.",
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["receipt_id"],
+        "properties": {"receipt_id": {"type": "string", "minLength": 3}}
+      }
+    },
+    {
+      "name": "comms.message.send",
+      "title": "Send controlled communication",
+      "description": "Create a classified communication request and route it through configured adapters.",
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["channels", "subject", "message", "idempotency_key"],
+        "properties": {
+          "channels": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {"enum": ["github", "slack", "notion", "dropbox", "riveros"]}
+          },
+          "classification": {"enum": ["public", "internal-operational", "confidential"]},
+          "subject": {"type": "string", "minLength": 1, "maxLength": 200},
+          "message": {"type": "string", "minLength": 1, "maxLength": 4000},
+          "resource_links": {"type": "array", "items": {"type": "string"}},
+          "receipt_required": {"type": "boolean"},
+          "idempotency_key": {"type": "string", "minLength": 16}
+        }
+      }
+    },
+    {
+      "name": "comms.message.status",
+      "title": "Read communication status",
+      "description": "Read the status of a communication request from the controlled outbox.",
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["communication_id"],
+        "properties": {"communication_id": {"type": "string", "minLength": 3}}
+      }
+    }
+  ]
+}

--- a/rail-tsconfig.json
+++ b/rail-tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"],
+    "strict": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "rail-cli/**/*.ts",
+    "rail-mcp/**/*.ts"
+  ]
+}


### PR DESCRIPTION
## What changed

- adds a versioned Chinese/Pinyin-to-canonical command registry
- adds `railctl`, a compile-first CLI for node resolution, node-log export/import preparation, queries, receipts and communications
- requires exact canonical confirmation plus environment-held MCP transport credentials before execution
- loads a signed authorization capability only at execution time and keeps it out of compile-only output
- adds a stdio MCP server implementing initialization, tool discovery and tool calls
- enforces authorization inside `tools/call`, including callers that bypass `railctl`
- adds a signed Warden node-registry resolver exposed as `rail.nodes.resolve`
- verifies dual Ed25519 proofs: DigitalMe actor and Warden policy
- binds every capability to the SHA-256 digest of the exact Warden-signed node registry
- enforces expiry, exact tool/node grants, node status, export-duration limits, query limits, channels and classifications
- keeps node-log operations preview-only
- permits communications only through an explicitly enabled controlled local outbox
- stores sanitized authorization decisions without copying signatures or trust keys into operation records
- adds schemas, cryptographic tests, documentation and CI conformance artifacts

## Safety boundary

- no live rail node is connected
- no external Slack, Notion, Dropbox, GitHub or RiverOS adapter is activated
- no reusable private key is committed; tests generate Ed25519 keys in memory
- trust configuration contains public keys only and is loaded from controlled paths
- log import is `prepare` plus quarantine only; there is no commit action
- node operations produce authorized preview receipts and resource links
- communications require `RAIL_MCP_EXECUTION_ENABLED=true` and `RAIL_MCP_OUTBOX_DIR`
- confidential communications require a separate environment gate
- transport credentials are read from environment variables and are rejected if embedded in tool arguments
- the custom deterministic JSON canonicalizer remains draft pending a ratified canonicalization profile

## Required controlled configuration

- `RAIL_TRUST_STORE_PATH`
- `RAIL_NODE_REGISTRY_PATH`
- `RAIL_AUTHORIZATION_FILE` or `--authorization-file` / `--shouquan-wenjian`
- `RAIL_MCP_URL`
- `RAIL_MCP_TOKEN`

## Validation

- `npm run check:rail`
- `npm run test:rail`
- representative export command compiled in GitHub Actions
- conformance artifact includes the compiled command, command registry, MCP contracts, authorization schema, node-registry schema and SHA-256 manifest

## Protocol basis

The implementation follows MCP JSON-RPC initialization and `tools/list` / `tools/call` conventions, with stdio as the local server transport. Streamable HTTP execution in the CLI performs initialization and supports JSON or SSE responses.

## Deferred intentionally

- live node-log readers or writers
- RiverOS receipt verification and durable idempotency
- external channel adapter workers
- authoritative import commit
- trust-key rotation and revocation feeds
- formal canonicalization ratification
